### PR TITLE
Remove masthead transition. Fixes #11

### DIFF
--- a/app/elements/countdown-timer/countdown-timer-enumerations.js
+++ b/app/elements/countdown-timer/countdown-timer-enumerations.js
@@ -20,6 +20,13 @@ IOWA.CountdownTimer.Colors = {
   Label: 'hsla(0, 0%, 0%, 0.57)',
   Rundown: [
     {
+      background: {h: 198, s: 16, l: 84, a: 1},
+      dark: {h: 187, s: 100, l: 38, a: 1},
+      medium: {h: 187, s: 72, l: 71, a: 1},
+      light: {h: 187, s: 72, l: 93, a: 1}
+    },
+
+    {
       background: {h: 188, s: 83, l: 46, a: 1},
       dark: {h: 187, s: 100, l: 38, a: 1},
       medium: {h: 187, s: 72, l: 71, a: 1},

--- a/app/elements/countdown-timer/countdown-timer.html
+++ b/app/elements/countdown-timer/countdown-timer.html
@@ -213,7 +213,7 @@ Creates a countdown timer to a specific date.
             }
             this.start();
             this.show();
-          });
+          }, 600); // 600ms delay starting countdown de-janks io-logo loading animation.
         },
 
         detached: function() {

--- a/app/elements/io-logo.html
+++ b/app/elements/io-logo.html
@@ -189,17 +189,16 @@ Fired when loading animation is complete.
         // This runs forward and then in reverse, so wait for half of SHOW_FOR on
         // each iteration by calculating its offset.
         var offset = DURATION / (DURATION + this.SHOW_FOR / 2);
-        var animation = [
-          {
-            transform: 'scale(0)',
-            easing: 'cubic-bezier(0,0,0.21,1)'
-          },
-          {
-            transform: 'scale(1)',
-            offset: offset
-          },
-          { transform: 'scale(1)' }
-        ];
+        var animation = [{
+          transform: 'scale(0)',
+          easing: 'cubic-bezier(0,0,0.21,1)'
+        }, {
+          transform: 'scale(1)',
+          offset: offset
+        }, {
+          transform: 'scale(1)'
+        }];
+
         var player = this.$.o2.animate(animation, {
           delay: this.START_DELAY,
           duration: DURATION + this.SHOW_FOR / 2,

--- a/app/elements/io-logo.scss
+++ b/app/elements/io-logo.scss
@@ -47,7 +47,7 @@
 
 @media (min-width: $tablet-breakpoint-min) {
   :host-context(.io-live-mode) {
-     background-color: transparent !important;
+    background-color: transparent !important;
   }
 }
 
@@ -77,7 +77,7 @@
 }
 
 #o2 {
-  background-color: $color-bluegrey-100;
+  background-color: black;
   transform: scale(0);
   will-change: transform;
 

--- a/app/scripts/helper/elements.js
+++ b/app/scripts/helper/elements.js
@@ -160,18 +160,7 @@ IOWA.Elements = (function() {
     template.videoList = [];
     template.filteredVideoList = [];
 
-    template.rippleColors = {
-      'bg-cyan': '#00BCD4',
-      'bg-medium-grey': '#CFD8DC',
-      'bg-dark-grey': '#455A64',
-      'bg-photo': '#455A64'
-    };
-
-    template.mastheadBgClass = template.pages[template.selectedPage].mastheadBgClass;
-    template.navBgClass = template.mastheadBgClass;
-
-    IOWA.Util.setMetaThemeColor(
-        template.rippleColors[template.mastheadBgClass]);
+    IOWA.Util.setMetaThemeColor('#CFD8DC'); // bg-medium-grey in colors.scss.
 
     template.timezoneNames = {
       'GMT-11:00': {
@@ -814,14 +803,6 @@ IOWA.Elements = (function() {
         return false;
       }
       return this.pages[pageName].selectedSubpage == subpageName;
-    };
-
-    template._computeMastheadClass = function(pages, selectedPage) {
-      return pages[selectedPage].mastheadBgClass;
-    };
-
-    template._computeSignNavElementsClass = function(isPhoneSize, pages, selectedPage) {
-      return isPhoneSize ? '' : pages[selectedPage].mastheadBgClass;
     };
 
     template._disableNotify = function(notify) {

--- a/app/scripts/helper/page-animation.js
+++ b/app/scripts/helper/page-animation.js
@@ -38,6 +38,8 @@ IOWA.PageAnimation = (function() {
     fill: 'forwards'
   };
 
+  const RIPPLE_COLOR = '#fff';
+
   /**
    * Fades element out.
    * @param {Element} el DOM element.
@@ -400,20 +402,10 @@ IOWA.PageAnimation = (function() {
    */
   function playMastheadRippleTransition(startPage, endPage, e, sourceEl) {
     return new Promise(function(resolve, reject) {
-      var t = IOWA.Elements.Template;
-      var startBgClass = t.pages[startPage].mastheadBgClass;
-      var endBgClass = t.pages[endPage].mastheadBgClass;
-
-      var isFadeRipple = startBgClass === endBgClass;
-      var mastheadColor = t.rippleColors[startBgClass];
-      var rippleColor = isFadeRipple ? '#fff' : t.rippleColors[endBgClass];
-
       var x = e.touches ? e.touches[0].pageX : e.pageX;
       var y = e.touches ? e.touches[0].pageY : e.pageY;
-      var duration = 300;//isFadeRipple ? 300 : 600;
       var rippleAnim = rippleEffect(
-            IOWA.Elements.Ripple, x, y, duration,
-            rippleColor, isFadeRipple);
+          IOWA.Elements.Ripple, x, y, 300, RIPPLE_COLOR, true);
       var animation = new GroupEffect([rippleAnim, contentSlideOut()]);
       play(animation, resolve);
     });
@@ -426,10 +418,6 @@ IOWA.PageAnimation = (function() {
   function playHeroTransitionStart(startPage, endPage, e, sourceEl) {
     var touchData = (e.type == 'touchstart') ? e.touches[0] : e;
     return new Promise(function(resolve, reject) {
-      var t = IOWA.Elements.Template;
-      var endBgClass = t.pages[endPage].mastheadBgClass;
-      var rippleColor = t.rippleColors[endBgClass];
-
       // TODO: This may need some perf tweaking for FF.
       var card = null;
       var currentEl = sourceEl;
@@ -440,7 +428,7 @@ IOWA.PageAnimation = (function() {
         }
       }
       play(pageCardTakeoverOut(
-          card, touchData.pageX, touchData.pageY, 300, rippleColor), resolve);
+          card, touchData.pageX, touchData.pageY, 300, RIPPLE_COLOR), resolve);
     });
   }
 

--- a/app/scripts/helper/router.js
+++ b/app/scripts/helper/router.js
@@ -22,8 +22,6 @@ IOWA.Router_ = function(window) {
 
   "use strict";
 
-  var MASTHEAD_BG_CLASS_REGEX = /(\s|^)bg-[a-z-]+(\s|$)/;
-
   /**
    * Replaces in-page <script> tag in xhr'd body content with runnable script.
    *
@@ -249,7 +247,6 @@ IOWA.Router_ = function(window) {
 
     // Update menu/drawer/subtabs selected item.
     this.t.selectedPage = pageName;
-    // this.t.pages[pageName].selectedSubpage = this.state.current.subpage;
     this.t.set(['pages', pageName, 'selectedSubpage'], this.state.current.subpage);
 
     IOWA.Elements.DrawerMenu.selected = pageName;
@@ -258,16 +255,9 @@ IOWA.Router_ = function(window) {
     if (this.state.current.page !== this.state.start.page) {
       document.body.id = 'page-' + pageName;
       document.title = pageMeta.title || 'Google I/O 2016';
-      IOWA.Util.setMetaThemeColor(
-          IOWA.Elements.Template.rippleColors[pageMeta.mastheadBgClass]);
 
-      // This cannot be updated via data binding, because the masthead
-      // is visible before the binding happens.
-      IOWA.Elements.Masthead.className = IOWA.Elements.Masthead.className.replace(
-        MASTHEAD_BG_CLASS_REGEX, ' ' + pageMeta.mastheadBgClass + ' ');
       // Reset subpage, since leaving the page.
       var startPage = this.state.start.page;
-      // this.t.pages[startPage].selectedSubpage = startPage.defaultSubpage;
       this.t.set(['pages', startPage, 'selectedSubpage'], startPage.defaultSubpage);
       // Scroll to top of new page.
       IOWA.Elements.ScrollContainer.scrollTop = 0;

--- a/app/styles/components/_app.scss
+++ b/app/styles/components/_app.scss
@@ -156,7 +156,6 @@ paper-progress {
 
 .bg-light-grey {
   background-color: $color-body;
-  // color: $color-text;
   color: $color-heading;
 
   h1, h2, h3, h4 {
@@ -216,24 +215,6 @@ paper-progress {
   }
 }
 
-.bg-globe {
-  background-image: url(../images/home/globe-1440.jpg);
-  background-repeat: no-repeat;
-  background-position: 50% 60px;
-  background-size: 150%;
-}
-
-.attend__globe {
-  min-height: 150px;
-  opacity: 0;
-  transition: opacity 1000ms linear;
-  will-change: opacity;
-
-  &.show {
-    opacity: 1;
-  }
-}
-
 .page__section {
   @include keyline-16();
   padding-top: $desktopKeyline;
@@ -255,37 +236,6 @@ paper-progress {
   height: 120px;
   background: url(../images/io15-hash-on-white-solid.png) no-repeat 50% 50%;
   background-size: contain;
-}
-
-.bg-cyan {
-  .io__hash {
-    background-image: url(../images/io15-hash-on-blue-solid.png);
-  }
-}
-
-.io-countdown {
-  height: 194px;
-
-  countdown-timer {
-    height: 180px;
-    max-width: 100%;
-  }
-
-  h4 {
-    @include typo-button();
-
-    a {
-      color: inherit;
-    }
-  }
-}
-
-#iolive {
-  opacity: 0;
-  &.show {
-    transition: opacity 400ms cubic-bezier(0,0,0.2,1) 800ms;
-    opacity: 1;
-  }
 }
 
 .io-main {
@@ -400,9 +350,6 @@ paper-progress {
   .navbar__overlay {
     font-size: 16px;
   }
-  .attend__globe {
-    height: 150px;
-  }
 }
 
 @media (min-width: $tablet-breakpoint-min) {
@@ -425,13 +372,6 @@ paper-progress {
     margin: 80px auto;
     margin-left: -$hashWidth !important;
     height: 160px;
-  }
-  .bg-globe {
-    background-position: 50% 0;
-  }
-  .attend__globe {
-    margin-top:  $desktopKeyline;
-    height: 500px;
   }
   h1 {
     @include typo-heading-1();
@@ -481,12 +421,6 @@ paper-progress {
     font-size: 16px;
     line-height: 24px;
     font-weight: 500;
-  }
-}
-
-@media (min-resolution: 2.0dppx), (-webkit-min-device-pixel-ratio: 2), (min-width: $tablet-breakpoint-min) {
-  .bg-globe {
-    background-image: url(../images/home/globe-1440@2x.jpg);
   }
 }
 

--- a/app/styles/components/_masthead.scss
+++ b/app/styles/components/_masthead.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Google Inc. All rights reserved.
+ * Copyright 2016 Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@
   width: 60px;
 
   &.medium {
-    // height: 136px;
     width: 177px;
     height: 128px;
   }
@@ -30,9 +29,6 @@
     height: 184px;
     width: 256px;
   }
-  // &.huge {
-  //   height: 272px;
-  // }
 
   /* Adds a white circle behind the I/O logo as a focus state */
   &::after {
@@ -54,17 +50,9 @@
   &.bg-medium-grey {
     color: $color-bluegrey-700;
   }
-  &.bg-cyan {
-    color: $color-cyan-900;
-  }
-  &.bg-dark-grey {
-    color: $color-bluegrey-100;
-  }
-  &.bg-photo {
-    color: white;
-  }
 
   paper-toolbar {
+    // need :not(.style-scope) as to not collide with shady dom scoping for <io-logo> element.
     .io-logo:not(.style-scope) {
       margin-top: $mobileKeyline / 2;
       margin-left: $mobileKeyline / 2;
@@ -148,12 +136,11 @@ paper-drawer-panel {
 
 #navbar {
   background-color: transparent;
-  // height: $navbarHeight;
+  color: inherit;
 
   paper-tabs {
     display: none;
     text-transform: uppercase;
-    background-color: inherit;
   }
 
   paper-tab {

--- a/app/styles/pages/home.scss
+++ b/app/styles/pages/home.scss
@@ -37,12 +37,6 @@ $name: 'page-home';
   position: absolute;
   top: 16px;
   left: 95px;
-  background-color: transparent;
-}
-
-.photo__masthead {
-  background: url(../images/home/keynote2015.jpg) no-repeat 50% 30%;
-  background-size: cover;
 }
 
 .card__photo--stage {

--- a/app/templates/about.html
+++ b/app/templates/about.html
@@ -1,7 +1,5 @@
 {% define "title" %}About I/O{% end %}
 
-{% define "mastheadBgClass" %}bg-dark-grey{% end %}
-
 {% define "masthead" %}
   <h1><i18n-msg msgid="about">About</i18n-msg></h1>
 {% end %}

--- a/app/templates/error_404.html
+++ b/app/templates/error_404.html
@@ -1,7 +1,5 @@
 {% define "title" %}404 Not Found{% end %}
 
-{% define "mastheadBgClass" %}bg-cyan{% end %}
-
 {% define "content" %}
 
 <section class="page__section" layout horizontal center-center>

--- a/app/templates/error_500.html
+++ b/app/templates/error_500.html
@@ -1,7 +1,5 @@
 {% define "title" %}500 Internal Error{% end %}
 
-{% define "mastheadBgClass" %}bg-cyan{% end %}
-
 {% define "content" %}
 
 <section class="page__section" layout horizontal center-center>

--- a/app/templates/faq.html
+++ b/app/templates/faq.html
@@ -1,7 +1,5 @@
 {% define "title" %}FAQ{% end %}
 
-{% define "mastheadBgClass" %}bg-cyan{% end %}
-
 {% define "masthead" %}
   <h1><i18n-msg msgid="faq">FAQ</i18n-msg></h1>
 {% end %}

--- a/app/templates/form.html
+++ b/app/templates/form.html
@@ -1,7 +1,5 @@
 {% define "title" %}2015 I/O Extended event{% end %}
 
-{% define "mastheadBgClass" %}bg-dark-grey{% end %}
-
 {% define "masthead" %}
   <h1><i18n-msg msgid="submitevent">Register your 2015 I/O Extended event</i18n-msg></h1>
 {% end %}

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -1,11 +1,9 @@
 {% define "title" %}Google I/O 2016{% end %}
 
-{% define "mastheadBgClass" %}bg-cyan{% end %}
-
 {% define "masthead" %}
 <div id="countdown-container" class="photo__masthead--fullbleed" fit>
   <countdown-timer auto-start
-      bg-color="#00BCD4"
+      bg-color="rgb(83,97,250)"
       date="{% .StartDateStr %}"
       ease-in-time="490"
       wait-time="100"

--- a/app/templates/layout_full.html
+++ b/app/templates/layout_full.html
@@ -286,17 +286,17 @@ limitations under the License.
     }
   </style>
 </head>
-<body id="page-{% .Slug %}">
+<body id="page-{% .Slug %}" class="bg-medium-grey">
 
 <!-- Intro animation background is outside of Polymer to reduce perceived latency in polyfilled browsers. -->
 <div class="io-logo-container">
-  <io-logo width="312" height="165" page="{% .Slug %}" class="{% template "mastheadBgClass" .%}"></io-logo>
-  <div class="{% template "mastheadBgClass" .%}" iologobackground></div>
+  <io-logo width="312" height="165" page="{% .Slug %}" class="bg-medium-grey"></io-logo>
+  <div class="bg-medium-grey" iologobackground></div>
 </div>
 
 <paper-drawer-panel force-narrow>
   <div drawer layout vertical>
-    <paper-toolbar class="tall bg-cyan">
+    <paper-toolbar class="tall">
       <div class="top io-logo" flex></div>
       <div class="top">
         <img class="profilepic" hidden>
@@ -312,25 +312,21 @@ limitations under the License.
           <a href="./" data-ajax-link data-anim-drawer
              data-track-link="nav-drawer-home">Home</a>
         </paper-item>
-        <paper-item label="about">
+        <!-- <paper-item label="about">
           <a href="about" data-ajax-link data-anim-drawer
              data-track-link="nav-drawer-about">About</a>
-        </paper-item>
+        </paper-item> -->
         <paper-item label="schedule">
           <a href="schedule#day1" data-ajax-link data-anim-drawer
              data-track-link="nav-drawer-schedule">Schedule</a>
         </paper-item>
-        <paper-item label="offsite">
-          <a href="videos" data-ajax-link data-anim-drawer
-             data-track-link="nav-drawer-videos">Videos</a>
-        </paper-item>
         <paper-item label="onsite">
           <a href="onsite" data-ajax-link data-anim-drawer
-             data-track-link="nav-drawer-onsite">Onsite</a>
+             data-track-link="nav-drawer-onsite">Attending</a>
         </paper-item>
         <paper-item label="offsite">
           <a href="offsite" data-ajax-link data-anim-drawer
-             data-track-link="nav-drawer-offsite">Offsite</a>
+             data-track-link="nav-drawer-offsite">I/O Extended</a>
         </paper-item>
       </paper-menu>
     </div>
@@ -353,7 +349,7 @@ limitations under the License.
       <iron-media-query id="mq-desktop" query="(min-width:945px)"
                         query-matches="{{isDesktopSize}}"></iron-media-query>
 
-      <header class="masthead {% template "mastheadBgClass" .%} js-experiment-instrument js-experiment-instrument--no-top-margin" layout vertical>
+      <header class="masthead bg-medium-grey" layout vertical>
         <div class="masthead__ripple">
           <div class="masthead__ripple__content" id="masthead-ripple"></div>
         </div>
@@ -371,26 +367,26 @@ limitations under the License.
               <h4 class="masthead-subtitle">Shoreline Amphitheatre,<br>Mountain View, CA</h4>
             </div>
           </div>
-          <paper-tabs class$="white {{_computeMastheadClass(pages, selectedPage)}}"
-              attr-for-selected="label" selected="{{selectedPage}}" noink>
-            <paper-tab label="about" role="">
+          <paper-tabs class="white" attr-for-selected="label"
+                      selected="{{selectedPage}}" noink>
+            <!-- <paper-tab label="about" role="">
               <a href="about" data-ajax-link data-track-link="nav-about" data-transition="masthead-ripple-transition" layout horizontal center>About</a>
-            </paper-tab>
+            </paper-tab> -->
             <paper-tab label="schedule" role="">
               <a href="schedule#day1" data-ajax-link data-track-link="nav-schedule" data-transition="masthead-ripple-transition" layout horizontal center>Schedule</a>
             </paper-tab>
-            <paper-tab label="videos" role="">
+            <!-- <paper-tab label="videos" role="">
               <a href="videos" data-ajax-link data-track-link="nav-videos" data-transition="masthead-ripple-transition" layout horizontal center>Videos</a>
-            </paper-tab>
+            </paper-tab> -->
             <paper-tab label="onsite" role="">
-              <a href="onsite" data-ajax-link data-track-link="nav-onsite" data-transition="masthead-ripple-transition" layout horizontal center>Onsite</a>
+              <a href="onsite" data-ajax-link data-track-link="nav-onsite"
+                 data-transition="masthead-ripple-transition" layout horizontal center>Attending</a>
             </paper-tab>
             <paper-tab label="offsite" role="">
-              <a href="offsite" data-ajax-link data-track-link="nav-offsite" data-transition="masthead-ripple-transition" layout horizontal center>Offsite</a>
+              <a href="offsite" data-ajax-link data-track-link="nav-offsite" data-transition="masthead-ripple-transition" layout horizontal center>I/O Extended</a>
             </paper-tab>
           </paper-tabs>
-          <span id="signin-nav-elements" layout horizontal center
-                class$="{{_computeSignNavElementsClass(isPhoneSize, pages, selectedPage)}}">
+          <span id="signin-nav-elements" layout horizontal center>
             <!-- Note: Use on-click instead of on-tap so oauth popup is not blocked. Needs user gesture. -->
             <!-- /fakesignin is not a real endpoint, but we need it to trick router not
                  to return early from the document-level touchstart listener on mobile. -->

--- a/app/templates/offsite.html
+++ b/app/templates/offsite.html
@@ -1,7 +1,5 @@
 {% define "title" %}Attend Offsite{% end %}
 
-{% define "mastheadBgClass" %}bg-cyan{% end %}
-
 {% define "masthead" %}
   <!-- <div class="photo__masthead photo__masthead--fullbleed" fit>
   <div class="card__photo--stage"></div> -->

--- a/app/templates/onsite.html
+++ b/app/templates/onsite.html
@@ -1,7 +1,5 @@
 {% define "title" %}Onsite{% end %}
 
-{% define "mastheadBgClass" %}bg-dark-grey{% end %}
-
 {% define "defaultSubpage" %}event{% end %}
 {% define "selectedSubpage" %}event{% end %}
 

--- a/app/templates/registration.html
+++ b/app/templates/registration.html
@@ -1,7 +1,5 @@
 {% define "title" %}Registration{% end %}
 
-{% define "mastheadBgClass" %}bg-cyan{% end %}
-
 {% define "masthead" %}
   <h1><i18n-msg msgid="registration">Registration</i18n-msg></h1>
 {% end %}

--- a/app/templates/schedule.html
+++ b/app/templates/schedule.html
@@ -1,7 +1,5 @@
 {% define "title" %}Schedule{% end %}
 
-{% define "mastheadBgClass" %}bg-cyan{% end %}
-
 {% define "defaultSubpage" %}day1{% end %}
 {% define "selectedSubpage" %}day1{% end %}
 

--- a/app/templates/videos.html
+++ b/app/templates/videos.html
@@ -1,7 +1,5 @@
 {% define "title" %}Videos{% end %}
 
-{% define "mastheadBgClass" %}bg-photo{% end %}
-
 {% define "masthead" %}
 <div class="photo__masthead photo__masthead--fullbleed" fit>
   <div class="card__photo--stage" layout vertical center-center>

--- a/app/templates/widget.html
+++ b/app/templates/widget.html
@@ -1,7 +1,5 @@
 {% define "title" %}I/O Live Embed Widget{% end %}
 
-{% define "mastheadBgClass" %}bg-dark-grey{% end %}
-
 {% define "masthead" %}
   <h1>I/O Live Embed Widget</h1>
 {% end %}

--- a/util/gen-pages.go
+++ b/util/gen-pages.go
@@ -36,7 +36,7 @@ var (
 	templatesRoot = flag.String("d", "app/templates", "templates dir")
 
 	// metaTemplates defines which templates go into a page meta as string values.
-	metaTemplates = []string{"title", "mastheadBgClass", "defaultSubpage", "selectedSubpage"}
+	metaTemplates = []string{"title", "defaultSubpage", "selectedSubpage"}
 	// these are treated separately
 	skipFiles = []string{"embed.html"}
 )


### PR DESCRIPTION
R: @jeffposnick @crhym3 @nicolasgarnier  @pengying 

@crhym3 this removes `mastheadBgClass`. Please take a look.

This updates the nav to the new items for phase 1. 
