### PR TITLE
add babel to site-scripts compilation step

### DIFF
--- a/app/scripts/helper/util.js
+++ b/app/scripts/helper/util.js
@@ -287,22 +287,22 @@ IOWA.Util = IOWA.Util || (function() {
   };
 
   return {
-    createDeferred: createDeferred,
-    isFF: isFF,
-    isIE: isIE,
-    isIOS: isIOS,
-    isSafari: isSafari,
-    isTouchScreen: isTouchScreen,
-    setMetaThemeColor: setMetaThemeColor,
+    createDeferred,
+    isFF,
+    isIE,
+    isIOS,
+    isSafari,
+    isTouchScreen,
+    setMetaThemeColor,
     supportsHTMLImports: 'import' in document.createElement('link'),
-    smoothScroll: smoothScroll,
-    shortenURL: shortenURL,
-    getURLParameter: getURLParameter,
-    getStaticBaseURL: getStaticBaseURL,
-    setSearchParam: setSearchParam,
-    getEventSender: getEventSender,
-    removeSearchParam: removeSearchParam,
-    resizeRipple: resizeRipple,
-    reportError: reportError
+    smoothScroll,
+    shortenURL,
+    getURLParameter,
+    getStaticBaseURL,
+    setSearchParam,
+    getEventSender,
+    removeSearchParam,
+    resizeRipple,
+    reportError
   };
 })();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -194,8 +194,19 @@ gulp.task('concat-and-uglify-js', ['eslint', 'generate-page-metadata'], function
     return IOWA.appDir + '/scripts/' + script;
   });
 
+  // Only run our own scripts through babel.
+  var ownScriptsFilter = $.filter(
+      file => new RegExp(`${IOWA.appDir}/scripts/`).test(file.path),
+      {restore: true});
+
   var siteScriptStream = gulp.src(siteScripts)
     .pipe(reload({stream: true, once: true}))
+    .pipe(ownScriptsFilter)
+    .pipe($.babel({
+      presets: ['es2015'],
+      compact: false
+    }))
+    .pipe(ownScriptsFilter.restore)
     .pipe($.concat('site-scripts.js'));
 
   // analytics.js is loaded separately and shouldn't be concatenated.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "originProd": "https://events.google.com"
   },
   "devDependencies": {
+    "babel-preset-es2015": "^6.3.13",
     "blink-diff": "^1.0.7",
     "bower": "^1.6.5",
     "browser-sync": "^2.0.0-rc8",
@@ -25,12 +26,14 @@
     "glob": "^6.0.1",
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^3.1.0",
+    "gulp-babel": "^6.1.1",
     "gulp-cache": "^0.4.0",
     "gulp-changed": "^1.1.0",
     "gulp-chmod": "^1.2.0",
     "gulp-concat": "^2.4.3",
     "gulp-crisper": "^1.0.0",
     "gulp-eslint": "^1.1.1",
+    "gulp-filter": "^3.0.1",
     "gulp-foreach": "0.1.0",
     "gulp-if": "^2.0.0",
     "gulp-imagemin": "^2.1.0",


### PR DESCRIPTION
re #6 

The transformation is pretty transparent right now and only touches code that goes into `site-scripts.js`. I added a token es6 change to light the way.

Since this only affects dist/prod, we'll need to only write es6 that runs in your development browser of choice for now.
