### PR TITLE
Add `gulp setup` to the Setup instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Setup
 1. `git clone https://github.com/GoogleChrome/ioweb2016.git`
 2. `cd ioweb2016`
 3. `npm install`
+4. `gulp setup`
 
 If you plan on modifying source code, be a good citizen and:
 


### PR DESCRIPTION
This is needed to fetch the Go and Bower dependencies (plus installs the git presubmit hooks)
