### PR TITLE
Update twitter filter to #io16

### DIFF
--- a/app/temporary_api/social_feed.json
+++ b/app/temporary_api/social_feed.json
@@ -2,7 +2,7 @@
   {
     "kind": "tweet",
     "url": "https://twitter.com/googledevs/status/580786118427209729",
-    "text": "Lear\n <how> Instrument \u0026 Chrome Developer Relations built the sound-based I/O 2015 Experiment w/ WebGL, Web Audio #io15 http://t.co/HaS39hWG2J",
+    "text": "Lear\n <how> Instrument \u0026 Chrome Developer Relations built the sound-based I/O 2015 Experiment w/ WebGL, Web Audio #io16 http://t.co/HaS39hWG2J",
     "author": "@googledevs",
     "when": "2015-03-25T17:39:35Z",
     "urls": [
@@ -55,7 +55,7 @@
   {
     "kind": "tweet",
     "url": "https://twitter.com/googledevs/status/578710320358768640",
-    "text": "<script>alert('hello!')</script> The #io15 registration window has closed. We’ll let you know if you’ve been selected soon!",
+    "text": "<script>alert('hello!')</script> The #io16 registration window has closed. We’ll let you know if you’ve been selected soon!",
     "author": "@googledevs",
     "when": "2015-03-20T00:11:06Z",
     "urls": [],
@@ -64,7 +64,7 @@
   {
     "kind": "tweet",
     "url": "https://twitter.com/googledevs/status/578678893239873537",
-    "text": "Only 2hrs left to submit your #io15 registration application for Google I/O 2015 http://t.co/Tr7f0jXzAw",
+    "text": "Only 2hrs left to submit your #io16 registration application for Google I/O 2015 http://t.co/Tr7f0jXzAw",
     "author": "@googledevs",
     "when": "2015-03-19T22:06:14Z",
     "urls": [
@@ -83,7 +83,7 @@
   {
     "kind": "tweet",
     "url": "https://twitter.com/googledevs/status/578285048501178368",
-    "text": "Don’t forget, the #io15 registration window closes at 5pm PDT on 3/19 http://t.co/Tr7f0jXzAw",
+    "text": "Don’t forget, the #io16 registration window closes at 5pm PDT on 3/19 http://t.co/Tr7f0jXzAw",
     "author": "@googledevs",
     "when": "2015-03-18T20:01:14Z",
     "urls": [
@@ -102,7 +102,7 @@
   {
     "kind": "tweet",
     "url": "https://twitter.com/googledevs/status/577983798270246912",
-    "text": "For those on the other side of the world, the #io15 registration window is open until 5pm PDT on 3/19. http://t.co/Tr7f0jXzAw",
+    "text": "For those on the other side of the world, the #io16 registration window is open until 5pm PDT on 3/19. http://t.co/Tr7f0jXzAw",
     "author": "@googledevs",
     "when": "2015-03-18T00:04:10Z",
     "urls": [
@@ -121,7 +121,7 @@
   {
     "kind": "tweet",
     "url": "https://twitter.com/googledevs/status/577862981800701953",
-    "text": "The #io15 registration window is open. Don’t worry, you have until 5pm PDT on 3/19 to apply. http://t.co/Tr7f0jXzAw",
+    "text": "The #io16 registration window is open. Don’t worry, you have until 5pm PDT on 3/19 to apply. http://t.co/Tr7f0jXzAw",
     "author": "@googledevs",
     "when": "2015-03-17T16:04:05Z",
     "urls": [
@@ -140,7 +140,7 @@
   {
     "kind": "tweet",
     "url": "https://twitter.com/googledevs/status/575706314694782976",
-    "text": "Join us for Google I/O 2015 via the global I/O Extended program. Learn more at: http://t.co/tjQ1xrhxAD. #io15 #io15extended",
+    "text": "Join us for Google I/O 2015 via the global I/O Extended program. Learn more at: http://t.co/tjQ1xrhxAD. #io16 #io16extended",
     "author": "@googledevs",
     "when": "2015-03-11T17:14:16Z",
     "urls": [

--- a/backend/social.go
+++ b/backend/social.go
@@ -109,7 +109,7 @@ func fetchTweets(c context.Context, account string, tc chan *tweetEntry) {
 	params := url.Values{
 		"screen_name": {config.Twitter.Account},
 		"count":       {"200"},
-		"include_rts": {"true"},
+		"include_rts": {"false"},
 	}
 	url := config.Twitter.TimelineURL + "?" + params.Encode()
 	req, nil := http.NewRequest("GET", url, nil)


### PR DESCRIPTION
This change will also remove retweets: there are just too many of them
and the risk is we'll miss tweets originated from googledevs.

The code could be improved by looping over multiple requests in a task
queue but it adds a lot of complexity. Will get back to this as a P2/P3.

Closes #44
The rest of #44 will be closed by #61.

R: @ebidel 
