### PR TITLE
Remove overflow-y: scroll

### DIFF
--- a/app/styles/components/_masthead.scss
+++ b/app/styles/components/_masthead.scss
@@ -63,10 +63,6 @@ paper-drawer-panel {
     font-size: 14px;
     font-weight: 500;
   }
-  [main] {
-    overflow-y: scroll;
-    -webkit-overflow-scrolling: touch;
-  }
   paper-toolbar .bottom {
     font-size: 14px;
     line-height: 20px;


### PR DESCRIPTION
R: @ebidel, @GoogleChrome/ioweb-core

There's currently an ugly extra scrollbar (on desktop browsers that show scrollbars).

![image](https://cloud.githubusercontent.com/assets/1749548/12730988/7870c52c-c8fc-11e5-84cb-575772bbc7af.png)

This change removes the `overflow-y: scroll` that is causing it. Here's some context from last year when we added it in: https://github.com/GoogleChrome/ioweb2015/pull/490

This year, the scrollable portions of the page (should?) all be children of `<paper-header-panel>`, meaning that `<paper-drawer-panel>` shouldn't end up scrollable. That's my interpretation, at least. 

![image](https://cloud.githubusercontent.com/assets/1749548/12731051/cd11144c-c8fc-11e5-84dc-8ca33f36f680.png)
