### PR TITLE
Offline support for Firebase updates.

### DIFF
--- a/app/scripts/helper/firebase.js
+++ b/app/scripts/helper/firebase.js
@@ -345,7 +345,7 @@ class IOFirebase {
       // browser, or if writing to IndexedDB failed for some reason. That should
       // not prevent the Firebase write from being attempted, though, so just
       // catch() the error here.
-      window.debugLog('Error in IOFirebase._queueOperation()', error);
+      debugLog('Error in IOFirebase._queueOperation()', error);
     });
   }
 
@@ -364,7 +364,7 @@ class IOFirebase {
     }).catch(error => {
       // This might have rejected if IndexedDB is unavailable in the current
       // browser, or if writing to IndexedDB failed for some reason.
-      window.debugLog('Error in IOFirebase._dequeueOperation()', error);
+      debugLog('Error in IOFirebase._dequeueOperation()', error);
     });
   }
 


### PR DESCRIPTION
R: @nicolasgarnier @ebidel @GoogleChrome/ioweb-core 

Here are some code changes to make Firebase updates robust enough to handle being offline.

It uses a model proposed by the Firebase team, with Promises for chaining async operations:
1. Queue update in IDB.
2. Attempt to make update in Firebase.
3. When there's a response from Firebase, clear queued update from IDB.

When the user is offline, 3. won't happen, so the update will remain queued in IDB. The next time the user auths with Firebase, any previously queued updates are replayed.

After consultation with @nicolasgarnier, I refactored all the [`.update()` calls to `.set()` calls](https://github.com/GoogleChrome/ioweb2016/blob/master/firebase-security-rules.json), since those are much easier to queue in IDB. (If we need to queue `.update()`s at some point in the future, it will get tricky, because we'd need to maintain an Array of all the pending updates and replay them in the original order.)

Timestamps along with [Firebase validation rules](https://github.com/GoogleChrome/ioweb2016/blob/master/firebase-security-rules.json) are used to make sure we don't replay an update with a timestamp that's too old.

We're choosing to delete the IDB entry when 3. comes back with an error, since I don't think any of the errors are retriable. Errors due to out of date timestamps or bad auth aren't, for instance.

One thing that still needs to be dealt with is the UI around updates—we need to hook things up to the Toast to let users know when updates gets replayed, and make sure that the current UI around letting a user know when they're offline still makes sense. We also need to make sure that the session checkbox goes into a "disabled" state while the Firebase write is still pending. I'll file separate issues for all that.
