### PR TITLE
expand eslint to include build scripts

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,11 @@
     "no-warning-comments": 0,
     "require-jsdoc": 0,
     "valid-jsdoc": 0,
+    "no-implicit-coercion": [2, {
+      "boolean": false,
+      "number": true,
+      "string": true
+    }],
     "no-unused-vars": [2, {
       "vars": "all",
       "args": "after-used",

--- a/gulp_scripts/backend.js
+++ b/gulp_scripts/backend.js
@@ -105,7 +105,7 @@ function serve(opts, callback) {
   var proc;
   var spawnBackend = function() {
     var env = process.env;
-    env['RUN_WITH_DEVAPPSERVER'] = '1';
+    env.RUN_WITH_DEVAPPSERVER = '1';
     proc = spawn('bin/server', ['-addr', serverAddr],
                  {cwd: opts.dir, stdio: 'inherit', env: env});
   };
@@ -195,7 +195,8 @@ function generateServerConfig(dest, appenv) {
     IOWA.backendDir + '/server.config.template'
   ];
   var src;
-  for (var i = 0, f; f = files[i]; i++) {
+  for (var i = 0; i < files.length; i++) {
+    var f = files[i];
     if (fs.existsSync(f)) {
       src = f;
       break;
@@ -268,8 +269,8 @@ function decrypt(passphrase, callback) {
       callback(code);
       return;
     }
-    spawn('tar', ['-x', '-f', tarFile, '-C', IOWA.backendDir], {stdio: 'inherit'}).
-    on('exit', fs.unlink.bind(fs, tarFile, callback));
+    spawn('tar', ['-x', '-f', tarFile, '-C', IOWA.backendDir], {stdio: 'inherit'})
+      .on('exit', fs.unlink.bind(fs, tarFile, callback));
   });
 }
 
@@ -296,11 +297,10 @@ function encrypt(passphrase, callback) {
     if (passphrase) {
       args.push('-pass', 'pass:' + passphrase);
     }
-    spawn('openssl', args, {stdio: 'inherit'}).
-    on('exit', fs.unlink.bind(fs, tarFile, callback));
+    spawn('openssl', args, {stdio: 'inherit'})
+      .on('exit', fs.unlink.bind(fs, tarFile, callback));
   });
 }
-
 
 module.exports = {
   test: test,
@@ -313,4 +313,4 @@ module.exports = {
   installDeps: installDeps,
   generateServerConfig: generateServerConfig,
   generateGAEConfig: generateGAEConfig
-}
+};

--- a/gulp_scripts/screenshots.js
+++ b/gulp_scripts/screenshots.js
@@ -27,7 +27,7 @@ var fs = require('fs');
 var glob = require('glob');
 var path = require('path');
 var spawn = require('child_process').spawn;
-var sprintf = require("sprintf-js").sprintf;
+var sprintf = require('sprintf-js').sprintf;
 var util = require('gulp-util');
 var webdriver = require('selenium-webdriver');
 
@@ -53,8 +53,8 @@ function seleniumInstall() {
 function git(args) {
   var commandLine = 'git ' + args.join(' ');
   util.log('Running', commandLine);
-  return new Promise(function(resolve, reject) {
-    var gitCommand = exec(commandLine, function(error, output) {
+  return new Promise(function(resolve) {
+    exec(commandLine, function(error, output) {
       if (error) {
         util.log(error);
         // git exits with an error status when, e.g., there's nothing to restore with git stash pop
@@ -166,7 +166,7 @@ function compareScreenshots() {
   var diffPromises = Object.keys(fileNameToPaths).map(function(fileName) {
     return new Promise(function(resolve, reject) {
       var paths = fileNameToPaths[fileName];
-      if (paths.length == 2) {
+      if (paths.length === 2) {
         var diff = new BlinkDiff({
           imageAPath: paths[0],
           imageBPath: paths[1],
@@ -207,8 +207,12 @@ module.exports = function(branchOrCommit, serverRoot, url, pages, widths, height
   var parsedUrl = new URL(url);
   // Return a no-op promise that will be run if an exception is thrown before the server
   // needs to be stopped or before the git state needs to be restored.
-  var restorePromise = function() { return Promise.resolve() };
-  var stopServerPromise = function() { return Promise.resolve() };
+  var restorePromise = function() {
+    return Promise.resolve();
+  };
+  var stopServerPromise = function() {
+    return Promise.resolve();
+  };
   var cleanup = function(error) {
     return stopServerPromise()
       .then(restorePromise)
@@ -250,7 +254,9 @@ module.exports = function(branchOrCommit, serverRoot, url, pages, widths, height
       // Restore the git state then set restorePromise back to a function returning a no-op promise,
       // since it is run as part of the cleanup().
       return restorePromise().then(function() {
-        restorePromise = function() { return Promise.resolve() };
+        restorePromise = function() {
+          return Promise.resolve();
+        };
       });
     })
     .then(function() {

--- a/wct.conf.js
+++ b/wct.conf.js
@@ -5,5 +5,5 @@ module.exports = {
     local: {
       browsers: ['chrome']
     }
-  },
+  }
 };


### PR DESCRIPTION
@all

starts addressing #93 

expands testing to include `gulpfile.js`, `wct.conf.js`, and `gulp_scripts/*.js` and the needed fixes to get them to pass.
