### PR TITLE
add isEdge util and log unsupported UA strings

### DIFF
--- a/app/elements/io-live.html
+++ b/app/elements/io-live.html
@@ -578,7 +578,7 @@ Fired when the mode changes.
       this.$.livewidget.classList.add('transitioning');
 
       // Make sure FAB closes in browsers that don't support the new CSS clip-path.
-      if (IOWA.Util.isFF() || IOWA.Util.isIE()) {
+      if (IOWA.Util.isFF() || IOWA.Util.isIE() || IOWA.Util.isEdge()) {
         this.onFabTransition();
       }
     },

--- a/app/scripts/helper/util.js
+++ b/app/scripts/helper/util.js
@@ -122,6 +122,10 @@ IOWA.Util = IOWA.Util || (function() {
     return (/Trident/gi).test(userAgent);
   }
 
+  function isEdge() {
+    return /Edge/i.test(navigator.userAgent);
+  }
+
   function isFF() {
     var userAgent = navigator.userAgent;
     return (/Firefox/gi).test(userAgent);
@@ -303,6 +307,7 @@ IOWA.Util = IOWA.Util || (function() {
     createDeferred,
     isFF,
     isIE,
+    isEdge,
     isIOS,
     isSafari,
     isTouchScreen,

--- a/app/templates/layout_error.html
+++ b/app/templates/layout_error.html
@@ -163,7 +163,7 @@ limitations under the License.
 
     if (!supported) {
       // Note: pageview is recorded when IOWA.Analytics is setup.
-      IOWA.Analytics.trackEvent('Polymer', 'unsupported-browser', null, null, function() {
+      IOWA.Analytics.trackEvent('Polymer', 'unsupported-browser', navigator.userAgent, null, function() {
         window.location = {% url "upgrade" %};
       });
     }

--- a/app/templates/layout_full.html
+++ b/app/templates/layout_full.html
@@ -157,7 +157,7 @@ limitations under the License.
 
     if (!supported) {
       // Note: pageview is recorded when IOWA.Analytics is setup.
-      IOWA.Analytics.trackEvent('Polymer', 'unsupported-browser', null, null, function() {
+      IOWA.Analytics.trackEvent('Polymer', 'unsupported-browser', navigator.userAgent, null, function() {
         window.location = {% url "upgrade" %};
       });
     }


### PR DESCRIPTION
closes #48

@ebidel et al.

Edge (12 and 13) passes our UA sniff correctly, so not sure what was going on with Santa.
- Adds `isEdge` util to differentiate Edge, but `isIE` is only used in one place, so no extensive changes needed.
- Also logs raw UA string to analytics on `unsupported-browser` so that _if_ a large population of browsers are incorrectly rejected from the site we have the actual string to test and see where it's going wrong.
