### PR TITLE
Fab shouldn't auto apply tabindex

### DIFF
--- a/app/templates/layout_full.html
+++ b/app/templates/layout_full.html
@@ -397,7 +397,7 @@ limitations under the License.
       <a id="fabAnchor" href="#" on-click="backToTop"
          data-track-link="link-backtotop" tabindex="-1"
          aria-hidden="true" aria-label="back to top">
-        <paper-fab icon="io:expand-less" noink mini="[[app.isPhoneSize]]"></paper-fab>
+        <paper-fab icon="io:expand-less" noink mini="[[app.isPhoneSize]]" tabindex="-1"></paper-fab>
       </a>
     </div>
 


### PR DESCRIPTION
The fab auto applies a tabindex of 0 but you can't actually interact with it. Instead you only need to interact with the anchor around the fab which is already implicitly focusable.
