### PR TITLE
Manage focus on page navigation

### DIFF
--- a/app/scripts/helper/a11y.js
+++ b/app/scripts/helper/a11y.js
@@ -19,11 +19,17 @@ window.IOWA = window.IOWA || {};
 IOWA.A11y = IOWA.A11y || (function() {
   'use strict';
 
+  // Used by focuseNewPage. Instructs the app to only manage focus if
+  // this is not the first page the user is seeing. IOW, only manage
+  // focus in response to a user action, not their intial visit to the URL.
+  var isInitialPage = true;
+
   function init() {
     // Differentiate focus coming from mouse and keyboard.
     addFocusStates('.io-logo-link');
     addFocusStates('#navbar paper-tabs a');
     document.addEventListener('toast-message', announceLiveChange);
+    document.addEventListener('page-transition-done', focusNewPage);
   }
 
   // Handlers managed by the addFocusStates and removeFocusStates methods.
@@ -88,11 +94,22 @@ IOWA.A11y = IOWA.A11y || (function() {
     }, 1000);
   }
 
+  // Move focus to new page content after it has been lazy loaded in
+  function focusNewPage() {
+    if (isInitialPage) {
+      isInitialPage = false;
+      return;
+    }
+
+    IOWA.Elements.LazyPages.selectedPage.focus();
+  }
+
   return {
     init: init,
     addFocusStates: addFocusStates,
     removeFocusStates: removeFocusStates,
     focusNavigation: focusNavigation,
-    announceLiveChange: announceLiveChange
+    announceLiveChange: announceLiveChange,
+    focusNewPage: focusNewPage
   };
 })();

--- a/app/templates/layout_full.html
+++ b/app/templates/layout_full.html
@@ -368,25 +368,29 @@ limitations under the License.
            https://github.com/GoogleChrome/ioweb2016/blob/master/gulp_scripts/service-worker.js -->
       <lazy-pages>
         <template is="dom-if" name="home" restamp>
-          <io-home-page app="[[app]]" date="{% .StartDateStr %}"></io-home-page>
+          <io-home-page
+              app="[[app]]"
+              date="{% .StartDateStr %}"
+              tabindex="-1"></io-home-page>
         </template>
         <template is="dom-if" name="about" restamp>
-          <io-about-page app="[[app]]"></io-about-page>
+          <io-about-page app="[[app]]" tabindex="-1"></io-about-page>
         </template>
         <template is="dom-if" name="onsite" restamp>
-          <io-onsite-page app="[[app]]"></io-onsite-page>
+          <io-onsite-page app="[[app]]" tabindex="-1"></io-onsite-page>
         </template>
         <template is="dom-if" name="offsite" restamp>
-          <io-extended-page app="[[app]]"></io-extended-page>
+          <io-extended-page app="[[app]]" tabindex="-1"></io-extended-page>
         </template>
         <template is="dom-if" name="schedule" restamp>
           <io-schedule-page
               app="[[app]]"
               user="[[currentUser]]"
-              date="{% .StartDateStr %}"></io-schedule-page>
+              date="{% .StartDateStr %}"
+              tabindex="-1"></io-schedule-page>
         </template>
         <template is="dom-if" name="faq" restamp>
-          <io-faq-page app="[[app]]"></io-faq-page>
+          <io-faq-page app="[[app]]" tabindex="-1"></io-faq-page>
         </template>
       </lazy-pages>
 


### PR DESCRIPTION
Moves focus to new page content after it has been lazy loaded (otherwise a screenreader user will have no indication that anything has changed).

If this change is acceptable then we may want to also explicitly set `outline: none` on the pages that we're focusing (even though, oddly, I didn't see a focus ring being applied but the style is there). I spoke with members of the Chrome a11y team and they were ok with this approach.
