### PR TITLE
Make logo inline-block

### DIFF
--- a/app/styles/components/_masthead.scss
+++ b/app/styles/components/_masthead.scss
@@ -17,6 +17,7 @@
 @import '../base/layout';
 
 .io-logo {
+  display: inline-block;
   background: url('../images/io.png') no-repeat;
   background-size: contain;
   height: 40px;


### PR DESCRIPTION
I noticed the logo is currently display block so the clickable anchor area is most of the entire top bar. There are these styles: https://github.com/GoogleChrome/ioweb2016/blob/master/app/styles/components/_masthead.scss#L28-L35 which do include an `inline-block` value but they don't see to be applied? @ebidel 
