### PR TITLE
Adds promise rejection GA tracking

### DIFF
--- a/app/scripts/bootstrap.js
+++ b/app/scripts/bootstrap.js
@@ -21,7 +21,7 @@
 
   function logRejectedPromises() {
     for (var reason of unhandledRejections.values()) {
-      IOWA.Analytics.trackError('unhandledrejection', reason);
+      IOWA.Analytics.trackError('UnhandledPromiseRejection', reason);
     }
 
     unhandledRejections.clear();


### PR DESCRIPTION
R: @ebidel @GoogleChrome/ioweb-core  

The global events are only supported in Chrome 49+ at the moment, so this should be an effective no-op in other browsers.

See
![image](https://cloud.githubusercontent.com/assets/1749548/13260396/3ed51000-da29-11e5-8269-c3ab2f668e63.png)
for an example of what the GA parameters look like. In particular, `ec=error`, `ea=unhandledrejection` and `el=<the error>`

Closes #91
