### PR TITLE
Get rid of registration.update() call

### DIFF
--- a/app/scripts/helper/service-worker-registration.js
+++ b/app/scripts/helper/service-worker-registration.js
@@ -28,13 +28,6 @@ IOWA.ServiceWorkerRegistration = (function() {
         navigator.serviceWorker.register('service-worker.js', {
           scope: './'
         }).then(function(registration) {
-          // Check to see if there's an updated version of service-worker.js with new files to cache:
-          // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-update-method
-          // Note: registration.update() is not yet widely implemented.
-          if (typeof registration.update === 'function') {
-            registration.update();
-          }
-
           registration.onupdatefound = function() {
             // The updatefound event implies that registration.installing is set; see
             // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-container-updatefound-event


### PR DESCRIPTION
R: @ebidel @GoogleChrome/ioweb-core 

`registration.update()` causes the SW update process to kick off by fetching the script directly against the network, bypassing the cache. We have a short cache lifetime on the service worker script to begin with, so there's little value to be had by explicitly calling `update()`.

Removing it should also mean that there's only one [`net::ERR_FILE_EXISTS` error logged](https://bugs.chromium.org/p/chromium/issues/detail?id=541797) in Chrome, cutting down on the noise.
