### PR TITLE
Remove references to keynote2015.jpg

### DIFF
--- a/app/elements/io-about-page.html
+++ b/app/elements/io-about-page.html
@@ -140,7 +140,7 @@ limitations under the License.
 
   <template is="dom-if" if="[[app.fullscreenVideoActive]]" restamp>
     <div class="fullvideo__container" fit hidden>
-      <img src="/io2016/images/home/keynote2015.jpg"
+      <img src="/io2016/images/home/keynote.jpg"
            class="fullvideo_thumbnail"
            alt="Watch the I/O 2015 keynote" fit>
       <google-youtube video-id="7V-fIGMDsmE" height="100%" width="100%" fit

--- a/app/styles/pages/about.scss
+++ b/app/styles/pages/about.scss
@@ -40,7 +40,7 @@ main {
 }
 
 .card__photo--recap {
-  background-image: url(../images/home/keynote2015.jpg);
+  background-image: url(../images/home/keynote.jpg);
 }
 
 @media (min-width: $tablet-breakpoint-min) {


### PR DESCRIPTION
R: @ebidel @GoogleChrome/ioweb-core 

`/io2016/images/home/keynote2015.jpg` doesn't exist. `/io2016/images/home/keynote.jpg` does, though it's not a picture of Sundar.

I'm assuming that using the existing image as a placeholder is okay for now, but alternatively, we can re-add `keynote2015.jpg` if the picture needs to be of Sundar.

This should get rid of some 404 errors logged in the console.
