### PR TITLE
GA tracking for service worker states

### DIFF
--- a/app/scripts/analytics.js
+++ b/app/scripts/analytics.js
@@ -245,7 +245,7 @@ IOWA.Analytics = IOWA.Analytics || (function(exports) {
     if ('serviceWorker' in navigator) {
       this.trackEvent('serviceworker', 'supported', true);
       this.trackEvent('serviceworker', 'controlled',
-        Boolean(navigator.serviceWorker.controller));
+          Boolean(navigator.serviceWorker.controller));
     } else {
       this.trackEvent('serviceworker', 'supported', false);
     }


### PR DESCRIPTION
R: @ebidel @GoogleChrome/ioweb-core 

This will end up sending `el=1` when service workers are supported, and `el=0` when they're not. If supported, it will send `el=1` if the current page load is controlled by a service worker, or `el=0` if not (i.e. it's the first time the page has been visited and the service worker is not yet in control). 

Closes #165
