### PR TITLE
HTTP/2 preload backend support

### DIFF
--- a/backend/h2preload.json
+++ b/backend/h2preload.json
@@ -1,0 +1,13 @@
+{
+  "home": {
+    "elements/elements.html": {
+      "type": "document"
+    },
+    "elements/elements.js": {
+      "type": "script"
+    },
+    "styles/main.css": {
+      "type": "style"
+    }
+  }
+}

--- a/backend/handler_test.go
+++ b/backend/handler_test.go
@@ -29,6 +29,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/http2preload"
 )
 
 func TestServeIOExtEntriesStub(t *testing.T) {
@@ -202,6 +204,36 @@ func TestServeTemplate(t *testing.T) {
 		tag = `<link rel="canonical" href="` + test.canonical + `"`
 		if !strings.Contains(body, tag) {
 			t.Errorf("%d: %s does not contain %s", i, body, tag)
+		}
+	}
+}
+
+func TestH2Preload(t *testing.T) {
+	defer resetTestState(t)
+	defer preserveConfig()()
+	var err error
+	if h2config, err = http2preload.ReadManifest("h2preload.json"); err != nil {
+		t.Fatalf("h2preload: %v", err)
+	}
+	config.Prefix = "/root"
+
+	r := newTestRequest(t, "GET", "/", nil)
+	r.Host = "example.org"
+	w := httptest.NewRecorder()
+	serveTemplate(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("w.Code = %d; want %d", w.Code, http.StatusOK)
+	}
+	links := strings.Join(w.Header()["Link"], "\n")
+	want := []string{
+		"https://example.org/root/elements/elements.html",
+		"https://example.org/root/elements/elements.js",
+		"https://example.org/root/styles/main.css",
+	}
+	for _, v := range want {
+		if !strings.Contains(links, v) {
+			t.Errorf("want %s in\n%v", v, links)
 		}
 	}
 }

--- a/gulp_scripts/backend.js
+++ b/gulp_scripts/backend.js
@@ -32,7 +32,8 @@ function copy(appenv, callback) {
   gulp.src([
     IOWA.backendDir + '/**/*.go',
     IOWA.backendDir + '/*.yaml',
-    IOWA.backendDir + '/*.config'
+    IOWA.backendDir + '/*.config',
+    IOWA.backendDir + '/h2preload.json'
   ], {base: './'})
   .pipe(gulp.dest(IOWA.distDir))
   .on('end', function() {


### PR DESCRIPTION
Initial support, for homepage only.

The h2preload.json config file is stored alongside server.config and has the following format:

```
{
  "template-name": assets,
  "template-2": assets
}
```

where each assets entry is an element of [http2preload.Manifest](https://godoc.org/github.com/google/http2preload#Manifest).

This change will require "gulp godeps" command.
Closes #76.

R: @ebidel @brendankenny 
