### PR TITLE
Router uses click events; fix drawer links

### DIFF
--- a/app/bower.json
+++ b/app/bower.json
@@ -61,7 +61,6 @@
     "paper-fab": "PolymerElements/paper-fab#^1.0.0",
     "paper-item": "PolymerElements/paper-item#^1.0.0",
     "paper-input": "PolymerElements/paper-input#^1.1.6",
-    "paper-listbox": "PolymerElements/paper-listbox#^1.1.0",
     "paper-menu-button": "PolymerElements/paper-menu-button#^1.0.0",
     "paper-radio-group": "PolymerElements/paper-radio-group#^1.0.0",
     "paper-radio-button": "PolymerElements/paper-radio-button#^1.0.0",

--- a/app/elements/elements.html
+++ b/app/elements/elements.html
@@ -15,14 +15,12 @@ limitations under the License.
 
 <!-- Main app shell and components -->
 <link rel="import" href="../bower_components/paper-toolbar/paper-toolbar.html">
-<link rel="import" href="../bower_components/paper-menu/paper-menu.html">
 <link rel="import" href="io-icons.html">
 
 <link rel="import" href="../bower_components/paper-checkbox/paper-checkbox.html">
 <link rel="import" href="../bower_components/paper-item/paper-item.html">
 <link rel="import" href="../bower_components/paper-tabs/paper-tabs.html">
 
-<link rel="import" href="../bower_components/paper-listbox/paper-listbox.html">
 <link rel="import" href="../bower_components/paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../bower_components/paper-menu-button/paper-menu-button.html">
 
@@ -34,6 +32,7 @@ limitations under the License.
 <link rel="import" href="../bower_components/app-layout/app-scroll-effects/app-scroll-effects.html">
 
 <link rel="import" href="../bower_components/iron-media-query/iron-media-query.html">
+<link rel="import" href="../bower_components/iron-selector/iron-selector.html">
 
 <link rel="import" href="google-signin.html">
 <link rel="import" href="io-toast.html">

--- a/app/scripts/helper/router.js
+++ b/app/scripts/helper/router.js
@@ -47,13 +47,7 @@ IOWA.Router_ = function(window) {
     window.addEventListener('popstate', function() {
       this.navigate(window.location.href, 'page-slide-transition');
     }.bind(this));
-
-    // On iOS, we don't have event bubbling to the document level.
-    // http://www.quirksmode.org/blog/archives/2010/09/click_event_del.html
-    var eventName = IOWA.Util.isIOS() || IOWA.Util.isTouchScreen() ?
-        'touchstart' : 'click';
-
-    document.addEventListener(eventName, this.onClick.bind(this));
+    document.addEventListener('click', this.onClick.bind(this));
   };
 
   /**

--- a/app/styles/components/_masthead.scss
+++ b/app/styles/components/_masthead.scss
@@ -73,35 +73,35 @@
 
   .drawer-container {
     height: 100%;
-  }
-  paper-toolbar {
-    background-color: $color-cyan-300;
 
-    .bottom {
-      font-size: 14px;
-      line-height: 20px;
-      color: #1E535A;
-    }
+    paper-toolbar {
+      background-color: $color-cyan-300;
 
-    .io-logo {
-      background-image: url('../images/io-logo-white.png');
-    }
-  }
-  #drawer-menu {
-    padding: 0;
-    color: $color-bluegrey-600;
-    .iron-selected {
-      background-color: $color-bluegrey-50;
-    }
-  }
-  .drawer-panel-content {
-    overflow: auto;
+      .io-logo {
+        background-image: url('../images/io-logo-white.png');
+      }
 
-    paper-item {
-      font-size: inherit;
+      .bottom {
+        font-size: 14px;
+        line-height: 20px;
+        color: #1E535A;
+      }
+    }
+    .drawer-menu {
+      color: $color-bluegrey-600;
+      overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
 
       a {
-        line-height: 48px; // make a fill up paper-item
+        display: block;
+
+        &.iron-selected {
+          background-color: $color-bluegrey-50;
+        }
+
+        paper-item {
+          font-size: inherit;
+        }
       }
     }
   }

--- a/app/templates/layout_full.html
+++ b/app/templates/layout_full.html
@@ -229,33 +229,29 @@ limitations under the License.
         <div>Mountain View, CA</div>
       </div>
     </paper-toolbar>
-    <div class="drawer-panel-content" flex>
-      <!-- TODO: move to paper-listbox and remove import -->
-      <paper-menu id="drawer-menu" selected="{{selectedPage}}"
-                  attr-for-selected="label"
-                  on-iron-activate="closeDrawer">
-        <paper-item label="home">
-          <a href="./" data-ajax-link data-anim-drawer
-             data-track-link="nav-drawer-home">Home</a>
-        </paper-item>
-        <paper-item label="schedule">
-           <a href="schedule#day1" data-ajax-link
-           data-anim-drawer data-track-link="nav-drawer-schedule">Schedule</a>
-        </paper-item>
-        <paper-item label="attend">
-          <a href="attend" data-ajax-link data-anim-drawer
-             data-track-link="nav-drawer-attend">Attending</a>
-        </paper-item>
-        <paper-item label="extended">
-          <a href="extended" data-ajax-link data-anim-drawer
-             data-track-link="nav-drawer-extended">I/O Extended</a>
-        </paper-item>
-        <paper-item label="faq">
-          <a href="faq" data-ajax-link data-anim-drawer
-             data-track-link="nav-drawer-faq">FAQ</a>
-        </paper-item>
-      </paper-menu>
-    </div>
+    <iron-selector class="drawer-menu" selected="{{selectedPage}}" attr-for-selected="label"
+                   on-iron-activate="closeDrawer" activate-event="click" flex>
+      <a href="./" label="home" data-ajax-link data-anim-drawer
+         data-track-link="nav-drawer-home" tabindex="-1">
+        <paper-item>Home</paper-item>
+      </a>
+      <a href="schedule#day1" label="schedule" data-ajax-link data-anim-drawer
+         data-track-link="nav-drawer-schedule" tabindex="-1">
+        <paper-item>Schedule</paper-item>
+      </a>
+      <a href="attend" label="attend" data-ajax-link data-anim-drawer
+         data-track-link="nav-drawer-attend" tabindex="-1">
+        <paper-item>Attending</paper-item>
+      </a>
+      <a href="extended" label="extended" data-ajax-link data-anim-drawer
+         data-track-link="nav-drawer-extended" tabindex="-1">
+        <paper-item>I/O Extended</paper-item>
+      </a>
+      <a href="faq" label="faq" data-ajax-link data-anim-drawer
+         data-track-link="nav-drawer-faq" tabindex="-1">
+        <paper-item>FAQ</paper-item>
+      </a>
+    </iron-selector>
   </div>
 </app-drawer>
 


### PR DESCRIPTION
Changes the router to listen for click events on all devices. Fix the links in the drawer so that they can be tapped anywhere and be vertically scrolled.

cc @ebidel 
