### PR TITLE
Disable HTTP/2 push for homepage

### DIFF
--- a/backend/h2preload.json
+++ b/backend/h2preload.json
@@ -1,13 +1,2 @@
 {
-  "home": {
-    "elements/elements.html": {
-      "type": "document"
-    },
-    "elements/elements.js": {
-      "type": "script"
-    },
-    "styles/main.css": {
-      "type": "style"
-    }
-  }
 }

--- a/backend/handler_test.go
+++ b/backend/handler_test.go
@@ -211,9 +211,18 @@ func TestServeTemplate(t *testing.T) {
 func TestH2Preload(t *testing.T) {
 	defer resetTestState(t)
 	defer preserveConfig()()
+	// verify we have a h2preload config file
 	var err error
 	if h2config, err = http2preload.ReadManifest("h2preload.json"); err != nil {
 		t.Fatalf("h2preload: %v", err)
+	}
+	// replace actual file content with test entries
+	h2config = http2preload.Manifest{
+		"home": {
+			"elements/elements.html": http2preload.AssetOpt{Type: "document"},
+			"elements/elements.js":   http2preload.AssetOpt{Type: "script"},
+			"styles/main.css":        http2preload.AssetOpt{Type: "style"},
+		},
 	}
 	config.Prefix = "/root"
 


### PR DESCRIPTION
Also, decouple tests from h2preload.json config file.

Fixes #277
Closes #280 

@ebidel @brendankenny how about this?
