### PR TITLE
Remove paper-tabs activate event type

### DIFF
--- a/app/templates/layout_full.html
+++ b/app/templates/layout_full.html
@@ -274,7 +274,7 @@ limitations under the License.
         </a>
       </div>
       <paper-tabs attr-for-selected="label"
-                  selected="{{selectedPage}}">
+                  selected="{{selectedPage}}" activate-event="">
         <paper-tab label="schedule" role="">
           <a href="schedule#day1" data-ajax-link data-track-link="nav-schedule"
              data-transition="page-slide-transition"


### PR DESCRIPTION
Fixes #340

The issue here isn’t with document-level bubbling (which seems to work fine in iOS), but with the fact that `IronMenuBehavior` stops propagation on “activate” events from its children (even those from the light DOM). `paper-tabs` implements `IronMenuBehavior`, so the click events from the anchors were not bubbling up to the document-level router. The patch (read: hack) here is to set the `activateEvent` to an empty string so nothing can cause the activate event - `paper-tabs` will still change UI state tho, since that’ll be set by its parent after page navigation.

@frankiefu and I agree that this is not a great solution, but this should hold over until we fix it in our elements.

cc @ebidel 
