### PR TITLE
Remove tabindex on register button

### DIFF
--- a/app/elements/io-home-page.html
+++ b/app/elements/io-home-page.html
@@ -90,7 +90,7 @@ limitations under the License.
           <div>
             <a href="registration/apply" target="_blank"
                data-track-link="home-register-link">
-              <paper-button class="register-button" noink>Register now</paper-button>
+              <paper-button class="register-button" noink tabindex="-1">Register now</paper-button>
             </a>
           </div>
           <div layout flex end>


### PR DESCRIPTION
paper-button self applies a tabindex=0 but we don't want that as the outter anchor is already focusable.
