### PR TITLE
Checks socialList.selectedItem before accessing it

### DIFF
--- a/app/elements/io-home-page.html
+++ b/app/elements/io-home-page.html
@@ -361,16 +361,25 @@ limitations under the License.
 
       var socialList = this.$.social_card.querySelector('#social_list');
 
-      // Force initial item to visible
-      if (socialList.selectedItem) {
-        socialList.selectedItem.style.visibility = 'visible';
-      } else {
-        socialList.children[0].style.visibility = 'visible';
-      }
+      var forceVisible = function() {
+        // Force initial item to visible
+        if (socialList.selectedItem) {
+          socialList.selectedItem.style.visibility = 'visible';
+        } else {
+          socialList.children[0].style.visibility = 'visible';
+        }
+      };
+
+      forceVisible();
 
       _cycleSocialPostsInterval = window.setInterval(function() {
         socialList.selectNext();
-        socialList.selectedItem.style.visibility = 'visible';
+        // There appears to be a race condition that leads to
+        // socialList.selectedItem being undefined following
+        // socialList.selectNext().
+        // See https://github.com/GoogleChrome/ioweb2016/issues/409
+        // Use the forceVisible() helper to work around that bug.
+        forceVisible();
       }.bind(this), SOCIAL_CYCLE);
     },
 


### PR DESCRIPTION
R: @ebidel @GoogleChrome/ioweb-core 

This works around the most common exception following the Phase 2 launch. It doesn't get into the underlying issue that triggered the behavior, though.

See #409 
