### PR TITLE
Fix error about converting null to Object.

### DIFF
--- a/app/scripts/helper/schedule.js
+++ b/app/scripts/helper/schedule.js
@@ -174,7 +174,7 @@ class Schedule {
              .orderByChild('bookmarked')
              .equalTo(true)
              .once('value', function(data) {
-               let savedSessions = Object.keys(data.val());
+               let savedSessions = Object.keys(data.val() || {});
                IOWA.Elements.Template.set('app.savedSessions', savedSessions);
              });
 


### PR DESCRIPTION
If the user has no saved sessions then you get an error when trying to call `Object.keys()` on `null`.
