### PR TITLE
Adds an explicit size for non-mobile .schedule-toggle-buttons

### DIFF
--- a/app/elements/io-schedule.scss
+++ b/app/elements/io-schedule.scss
@@ -297,10 +297,6 @@ paper-radio-button {
   .schedule-title {
     font-size: 20px;
     line-height: 24px;
-
-    > div {
-      max-width: 95%;
-    }
   }
   .schedule-time {
     line-height: 24px;


### PR DESCRIPTION
R: @ebidel @GoogleChrome/ioweb-core 

Without this, the `<div class="schedule-toggle-buttons">` toggles between having zero width/height and `24px` width/height when you mouseover the row on desktop. This can cause long session names to wrap to the next line, which reflows the rest of the page:

![image](https://cloud.githubusercontent.com/assets/1749548/13995464/b98e6a0c-f0ff-11e5-8bea-43fa77edead5.png)

![image](https://cloud.githubusercontent.com/assets/1749548/13995477/c034a63c-f0ff-11e5-91f9-51b31deadc8d.png)

@ebidel if you have an idea for a cleaner solution than hardcoding `24px` into the CSS, I'd be open to that instead.
