### PR TITLE
Logs GA event when there's no IndexedDB support

### DIFF
--- a/app/scripts/helper/simple-db.js
+++ b/app/scripts/helper/simple-db.js
@@ -22,7 +22,10 @@
   var STORE = 'store';
 
   // Chrome iOS has window.indexeDB, but it is null.
-  if (!(global.indexedDB && indexedDB.open)) {
+  if (!(global.indexedDB && global.indexedDB.open)) {
+    if (global.IOWA && global.IOWA.Analytics) {
+      global.IOWA.Analytics.trackEvent('IndexedDB', 'unsupported');
+    }
     return;
   }
 


### PR DESCRIPTION
R: @ebidel @GoogleChrome/ioweb-core 

I'm going with a GA event instead of an error here, as I think it's closer in spirit to the events we log for whether service worker is supported or not.

I'm also only logging the negative and not sending a GA ping when IndexedDB is supported.

Closes #101 
