### PR TITLE
Actually resolve the undefined gapi issue

### DIFF
--- a/app/scripts/helper/auth.js
+++ b/app/scripts/helper/auth.js
@@ -27,8 +27,8 @@ IOWA.Auth = IOWA.Auth || (function() {
       if (user.isSignedIn()) {
         return user.getAuthResponse();
       }
-    } else if (gapi && gapi.auth) {
-      return gapi.auth.getToken();
+    } else if (window.gapi && window.gapi.auth) {
+      return window.gapi.auth.getToken();
     }
     return null;
   }


### PR DESCRIPTION
R: @ebidel 

Bah, #454 didn't actually solve the problem, as I discovered when I reloaded the page a few times and triggered a similar error.

This references `gapi` as a property of `window` and should be a better fix.
