### PR TITLE
Use correct path to simpledb_polyfill

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -192,7 +192,7 @@ gulp.task('concat-and-uglify-js', 'Crush JS', ['eslint', 'generate-page-metadata
   // This order needs to match the order in templates/layout_full.html
   var siteScripts = [
     // The SimpleDB polyfill needs to be run through Babel, so include it here.
-    'bower_components/simpledb_polyfill/index.js',
+    '../bower_components/simpledb_polyfill/index.js',
     'main.js',
     'pages.js',
     'helper/util.js',


### PR DESCRIPTION
R: @GoogleChrome/ioweb-core 

Gah. Not sure why I wasn't able to reproduce the issue initially, but I finally was able to and tracked it down to this path needing to be adjusted.

Closes #476 
