### PR TITLE
backend: add schedule duration field

### DIFF
--- a/backend/handler_test.go
+++ b/backend/handler_test.go
@@ -1539,6 +1539,7 @@ func TestFirstSyncEventData(t *testing.T) {
 		Block:     "3 PM",
 		Start:     "3:00 PM",
 		End:       "4:00 PM",
+		Duration:  "1 hour",
 		Filters: map[string]bool{
 			"Boxtalks":       true,
 			liveStreamedText: true,

--- a/backend/schedule.go
+++ b/backend/schedule.go
@@ -85,11 +85,12 @@ type eventSession struct {
 		Id string `json:"id"`
 	} `json:"relatedContent,omitempty"`
 
-	Day     int             `json:"day"`
-	Block   string          `json:"block"`
-	Start   string          `json:"start"`
-	End     string          `json:"end"`
-	Filters map[string]bool `json:"filters"`
+	Day      int             `json:"day"`
+	Block    string          `json:"block"`
+	Start    string          `json:"start"`
+	End      string          `json:"end"`
+	Duration string          `json:"duration"`
+	Filters  map[string]bool `json:"filters"`
 
 	// Update is used only api/user/updates
 	Update string `json:"update,omitempty"`
@@ -335,6 +336,7 @@ func slurpEventDataChunk(c context.Context, hc *http.Client, url string) (*event
 		s.Block = tzstart.Format("3 PM")
 		s.Start = tzstart.Format("3:04 PM")
 		s.End = s.EndTime.In(config.Schedule.Location).Format("3:04 PM")
+		s.Duration = durationStr(s.EndTime.Sub(s.StartTime))
 		s.Day = tzstart.Day()
 
 		if len(s.Speakers) == 0 {
@@ -673,6 +675,22 @@ func thumbURL(turl string) string {
 	}
 	k += j
 	return turl[:i] + "w" + turl[i+imageURLSizeMarkerLen:j] + turl[k:]
+}
+
+// durationStr returns duration d in a human readable simple format:
+// "2.5 hours", "1 hour", "30 minutes", etc.
+func durationStr(d time.Duration) string {
+	switch {
+	case d < time.Hour:
+		return fmt.Sprintf("%d minutes", int(d.Minutes()))
+	default:
+		v, u := d.Hours(), "hour"
+		if v > 1.5 {
+			u += "s"
+		}
+		return fmt.Sprintf("%g %s", d.Hours(), u)
+	}
+	return d.String()
 }
 
 // sortedSessionsList implements sort.Sort ordering items by:

--- a/backend/schedule_test.go
+++ b/backend/schedule_test.go
@@ -20,6 +20,24 @@ import (
 	"time"
 )
 
+func TestDurationStr(t *testing.T) {
+	tests := []struct {
+		in  time.Duration
+		out string
+	}{
+		{30 * time.Minute, "30 minutes"},
+		{time.Hour, "1 hour"},
+		{2 * time.Hour, "2 hours"},
+		{time.Hour + 30*time.Minute, "1.5 hour"},
+		{2*time.Hour + 30*time.Minute, "2.5 hours"},
+	}
+	for i, test := range tests {
+		if out := durationStr(test.in); out != test.out {
+			t.Errorf("%d: durationStr(%v) = %q; want %q", i, test.in, out, test.out)
+		}
+	}
+}
+
 func TestSubslice(t *testing.T) {
 	table := []struct{ in, items, out []string }{
 		{[]string{"a", "b", "c"}, []string{"a", "c"}, []string{"b"}},


### PR DESCRIPTION
Local copy of the schedule data needs to be re-synched with reset (/io2016/debug/sync) in order to get the duration field.

Closes #439 for now. Reopen if we need anything else from that bug.

@ebidel @brendankenny 
