### PR TITLE
Removes some 2015 cruft from the permissions error page

### DIFF
--- a/app/permissions.html
+++ b/app/permissions.html
@@ -19,7 +19,7 @@ limitations under the License.
   <title>Google I/O 2016 - Notification Permissions</title>
 
   <!-- See http://updates.html5rocks.com/2014/11/Support-for-theme-color-in-Chrome-39-for-Android -->
-  <meta name="theme-color" content="#eceff1">
+  <meta name="theme-color" content="#546E7A">
 
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700">
   <link rel="stylesheet" href="styles/main.css">
@@ -30,7 +30,7 @@ limitations under the License.
 <div id="permissions">
 
   <section class="page__section">
-    <img src="images/io-logo-white.png" class="iologo">
+    <img src="images/io-logo-grey.png" class="iologo">
   </section>
 
   <div class="card__container">

--- a/app/styles/pages/permissions.scss
+++ b/app/styles/pages/permissions.scss
@@ -26,7 +26,7 @@ $name: 'page-permissions';
 html, body {
   height: 100%;
   width: 100%;
-  background-color: $color-cyan-A400;
+  background-color: $color-bluegrey-50;
   overflow: auto;
 }
 


### PR DESCRIPTION
R: @wibblymat @GoogleChrome/ioweb-core 

This addresses the major issues with #473, namely the broken issue and cruft in the HTML left over from 2015. It also removes a bunch of meta tags we don't need, as folks shouldn't be sharing this page.

I'm going to leave #473 open, in case Eric wants to tweak the styles at some point.

Here's what it looks like on a Nexus 5X viewport:
![image](https://cloud.githubusercontent.com/assets/1749548/14218295/39d8673a-f821-11e5-94b2-6005f9df8479.png)

And a wider viewport:
![image](https://cloud.githubusercontent.com/assets/1749548/14218300/401066a2-f821-11e5-901d-d4438b607334.png)
