### PR TITLE
Use setAttribute instead of property assignment

### DIFF
--- a/app/scripts/helper/page-animation.js
+++ b/app/scripts/helper/page-animation.js
@@ -353,13 +353,13 @@ IOWA.PageAnimation = (function() {
       player.onfinish = function() {
         var main = IOWA.Elements.Main.querySelector('.active .slide-up');
         if (main) {
-          main.style = 'transform: none; opacity: 1';
+          main.setAttribute('style', 'transform: none; opacity: 1');
         }
 
         var mainDelayed = IOWA.Elements.Main.querySelector(
             '.active .slide-up-delay');
         if (mainDelayed) {
-          mainDelayed.style = 'transform: none; opacity: 1';
+          mainDelayed.setAttribute('style', 'transform: none; opacity: 1');
         }
 
         // Removes the effects of the animation b/c we've applied it inline.


### PR DESCRIPTION
R: @brendankenny @GoogleChrome/ioweb-core 

IE doesn't like assigning to DOM attributes directly from JavaScript while in strict mode.

I don't have a great way of testing this against a Windows machine right now, but I'm fairly certain this will resolve the issue.

Fixes #525 
