### PR TITLE
Fix #502: remove bottom rounded corners from schedule nav.

### DIFF
--- a/app/elements/io-schedule-subnav.html
+++ b/app/elements/io-schedule-subnav.html
@@ -87,7 +87,7 @@ Fired when the clears filter "x" is clicked.
   }
 </style>
 
-<nav class="subpage__nav bg-cyan-400 card" layout horizontal center justified relative>
+<nav class="subpage__nav bg-cyan-400" layout horizontal center justified relative>
   <template is="dom-if" if="[[!app.isPhoneSize]]">
     <paper-tabs id="subpage-tabs" class="white"
                 attr-for-selected="label"


### PR DESCRIPTION
Nav had class of `card` on it which created the rounded corners. Doesn't seem like it should be class `card` so removed it rather than adding CSS to change the border radius.
