### PR TITLE
Set max-width: 90% on the <google-map>

### DIFF
--- a/app/styles/pages/attend.scss
+++ b/app/styles/pages/attend.scss
@@ -268,6 +268,8 @@ $name: 'page-attend';
       height: 480px;
       background-color: #b3d1ff;
       position: relative;
+      max-width: 90%;
+      margin: 0 auto 0 auto;
 
       &::after {
         content: 'Loading...';

--- a/app/styles/pages/extended.scss
+++ b/app/styles/pages/extended.scss
@@ -140,6 +140,8 @@ $name: 'page-extended';
   }
 
   .find {
+    border-bottom: none;
+
     .details--icon {
       background: transparent url(../images/extended/icon-find.svg) center center no-repeat;
       background-size: 100%;
@@ -163,6 +165,8 @@ $name: 'page-extended';
     background-color: #b3d1ff;
     padding-bottom: (1 / 2) * 100%;
     position: relative;
+    max-width: 90%;
+    margin: 0 auto 0 auto;
 
     @media (max-width: $tablet-breakpoint-min) {
       padding-bottom: (2 / 3) * 100%;


### PR DESCRIPTION
This changes the visual design a bit so it would be good to have someone other than me review :smile: 

I'm doing a `max-width: 90%` across all viewport widths since the issue is really related to touch vs. no touch, not the viewport width. On a device that only supports touch, taking up the entire width makes scrolling difficult, regardless of how wide it is.

The Attending -> Travel map has been changed, too, but that's stuck on Loading... due to #550 

![image](https://cloud.githubusercontent.com/assets/1749548/14360409/371e48f0-fcc4-11e5-9d3d-a1abc3af05ef.png)
![image](https://cloud.githubusercontent.com/assets/1749548/14360420/48a8366c-fcc4-11e5-82bb-f25a56857abc.png)
![image](https://cloud.githubusercontent.com/assets/1749548/14360464/91110df2-fcc4-11e5-8e7a-8a8b2a71ee1c.png)

Fixes #562 
