### PR TITLE
Ensures that the AppLayout.scroll() has a valid target

### DIFF
--- a/app/elements/PageBehavior.html
+++ b/app/elements/PageBehavior.html
@@ -122,10 +122,16 @@ var PageBehavior = {
     var dest = IOWA.Elements.Main.querySelector(hash);
     if (dest) {
       var offset = opt_offset || 0;
+      // See https://github.com/GoogleChrome/ioweb2016/issues/561
+      // The target that's passed to Polymer.AppLayout.scroll needs to be an
+      // object with a style property.
+      var target = 'style' in IOWA.Elements.ScrollContainer ?
+        IOWA.Elements.ScrollContainer :
+        document.body;
       Polymer.AppLayout.scroll({
         top:  dest.getBoundingClientRect().top + offset,
         behavior: 'smooth',
-        target: IOWA.Elements.ScrollContainer
+        target: target
       });
     }
   },
@@ -267,8 +273,7 @@ var PageBehavior = {
     if (this._mainSubnav && !this._mainSubnav.classList.contains('offscreen')) {
       IOWA.Elements.Scroller.scrollTop = scrollTop + offset;
     }
-  },
-
+  }
 };
 
 IOBehaviors.PageBehavior = [PageBehavior, IOBehaviors.UtilBehavior];


### PR DESCRIPTION
R: @robdodson @brendankenny @GoogleChrome/ioweb-core 

I'm taking this approach rather than setting `IOWA.Elements.ScrollContainer = document.body`, since some of the other scroll behaviors rely on `IOWA.Elements.ScrollContainer` being set to `window`.

Fixes #561 
