### PR TITLE
Impose max-widths on the signin-settings-panel & container

### DIFF
--- a/app/styles/components/_masthead.scss
+++ b/app/styles/components/_masthead.scss
@@ -170,10 +170,15 @@ paper-tabs {
   & > .profilepic {
     margin-left: $mobileKeyline / 2;
   }
+
+  & > paper-menu-button > iron-dropdown {
+    max-width: 90%;
+  }
 }
 
 #signin-settings-panel {
   width: 344px;
+  max-width: 100%;
   color: $color-text;
   font-size: 14px;
   line-height: 18px;


### PR DESCRIPTION
R: @GoogleChrome/ioweb-core 

The signin settings panel will look like
![image](https://cloud.githubusercontent.com/assets/1749548/14364483/24bf769e-fcd7-11e5-95e4-23e6cad54745.png)
on a Nexus 5's viewport. The look on devices with significantly wider viewports shouldn't change since the `max-width: 90%` restriction won't apply.

Fixes #553
