### PR TITLE
Fix scrolled filter banner padding

### DIFF
--- a/app/templates/layout_full.html
+++ b/app/templates/layout_full.html
@@ -342,7 +342,7 @@ limitations under the License.
     <template is="dom-if" if="[[_isPage('schedule', selectedPage)]]" restamp>
       <io-schedule-subnav selected-subpage="{{selectedSubpage}}" app="[[app]]"
                           show-filters="{{showFilters}}"
-                          class="header_subnav offscreen"
+                          class="header_subnav offscreen card"
                           filters="[[_filters]]"
                           on-filters-clear="_onClearFilters"></io-schedule-subnav>
     </template>


### PR DESCRIPTION
R: @nicolasgarnier @jeffposnick 

Fixes a regression from https://github.com/GoogleChrome/ioweb2016/commit/03b19cdf120edc80cdf857aa8c16926ea9650d71. Where the left padding was lost on the scroll subnav.
