### PR TITLE
Hide .offscreen stuff for a11y

### DIFF
--- a/app/elements/io-schedule-subnav.html
+++ b/app/elements/io-schedule-subnav.html
@@ -35,10 +35,6 @@ Fired when the clears filter "x" is clicked.
     display: block;
   }
 
-  :host(.offscreen) {
-    display: none;
-  }
-
   @media (min-width: 768px) {
     #subpage-tabs {
       margin-left: -12px;

--- a/app/styles/base/a11y.scss
+++ b/app/styles/base/a11y.scss
@@ -92,3 +92,11 @@ paper-tab a.focused,
 .io-countdown h4 a:focus {
   outline-color: white;
 }
+
+/**
+ * Make sure anything labeled offscreen is not visible to AT
+ * You can't just make it opacity: 0 because it can still be tabbed to
+ */
+.offscreen {
+  visibility: hidden;
+}

--- a/app/templates/layout_full.html
+++ b/app/templates/layout_full.html
@@ -351,13 +351,15 @@ limitations under the License.
         <paper-tabs id="subpage-tabs" class="white"
                     attr-for-selected="label"
                     selected="{{selectedSubpage}}">
-          <paper-tab label="event" role="">
+          <paper-tab label="event" link>
             <a href="#event" data-track-link="attending-event" data-ajax-link
-               layout horizontal center-center>Event</a>
+               layout horizontal center-center
+               tabindex="-1">Event</a>
           </paper-tab>
-          <paper-tab label="travel" role="">
+          <paper-tab label="travel" link>
             <a href="#travel" data-track-link="attending-travel" data-ajax-link
-               layout horizontal center-center>Travel</a>
+               layout horizontal center-center
+               tabindex="-1">Travel</a>
           </paper-tab>
         </paper-tabs>
       </div>


### PR DESCRIPTION
I noticed we're using 2 sets of subnavs now so decided it'd be better if anything marked `.offscreen` was hidden from the keybaord
