### PR TITLE
Disable filter button and filter UI for a11y

### DIFF
--- a/app/elements/io-schedule-subnav.html
+++ b/app/elements/io-schedule-subnav.html
@@ -35,6 +35,10 @@ Fired when the clears filter "x" is clicked.
     display: block;
   }
 
+  paper-icon-button[disabled] {
+    color: inherit;
+  }
+
   @media (min-width: 768px) {
     #subpage-tabs {
       margin-left: -12px;
@@ -155,10 +159,13 @@ Fired when the clears filter "x" is clicked.
     </div>
 
     <div class="meta-filter" layout horizontal center
-         disabled$="[[_disableFiltering(selectedSubpage)]]"
+         disabled$="[[_disableFilterBtn]]"
          on-tap="toggleFilters">
       <span hidden$="[[app.isPhoneSize]]">Filter</span>
-      <paper-icon-button icon="io:filter-list" aria-label="Filter list"></paper-icon-button>
+      <!-- paper-icon-buttons supports its own disabled property. yay! -->
+      <paper-icon-button icon="io:filter-list" aria-label="Filter list"
+                         disabled="[[_disableFilterBtn]]">
+      </paper-icon-button>
     </div>
   </div>
 
@@ -209,6 +216,16 @@ Fired when the clears filter "x" is clicked.
       },
 
       /**
+       * When true, indicates the filter button should enter a disabled state
+       * and be hidden from assistive technology
+       */
+      _disableFilterBtn: {
+        type: Boolean,
+        value: false,
+        computed: '_disableFiltering(selectedSubpage)'
+      },
+
+      /**
        * Array of applied filters.
        */
       filters: {
@@ -228,11 +245,11 @@ Fired when the clears filter "x" is clicked.
     },
 
     _disableFiltering: function(selectedSubpage) {
-      var hide = selectedSubpage === 'myschedule' || selectedSubpage === 'agenda';
-      if (hide) {
+      var disabled = selectedSubpage === 'myschedule' || selectedSubpage === 'agenda';
+      if (disabled) {
         this.showFilters = false;
       }
-      return hide;
+      return disabled;
     },
 
     _showDaySelector: function(isMobile, selectedSubpage) {

--- a/app/elements/io-schedule.scss
+++ b/app/elements/io-schedule.scss
@@ -202,9 +202,11 @@ $filterBannerHeight: 72px;
   clip: rect(0px, 1600px, 0px, 0px);
   will-change: transform;
   padding-left: 0;
+  visibility: hidden; // Hide for a11y
 
   &[showfilters] {
     clip: rect(0px, 1600px, 76vh, 0px);
+    visibility: visible; // Display for a11y
   }
 
   &.fixed {
@@ -425,5 +427,3 @@ paper-radio-button {
     padding: 48px;
   }
 }
-
-


### PR DESCRIPTION
Currently the filter button applies a `disabled` attribute to its parent element but [per the spec](https://html.spec.whatwg.org/#enabling-and-disabling-form-controls:-the-disabled-attribute) that doesn't do anything (however we do use it for styling).

This change adds a `disableFilterBtn` property so it can be used in multiple places. Because `paper-icon-button` implements its own support for `disabled` we can use it to actually remove keyboard access on that element and it automatically marks itself `aria-disabled=true`.

This also toggles `visibility` for the filter UI to hide it from assistive technology when it's not displaying.
