### PR TITLE
Removes position: fixed on #sessionDetails when viewport > phone

### DIFF
--- a/app/elements/io-session-details.scss
+++ b/app/elements/io-session-details.scss
@@ -36,7 +36,6 @@ $color-section-border: #eaeaea;
 
 #sessionDetails {
   max-width: $tablet-breakpoint-min;
-  position: fixed;
 }
 
 #sessionDetails {
@@ -240,6 +239,7 @@ $color-section-border: #eaeaea;
     left: 0 !important;
     top: 0 !important;
     width: 100%;
+    position: fixed !important;
   }
 }
 


### PR DESCRIPTION
R: @GoogleChrome/ioweb-core 
CC: @valdrinkoshi

There's some more context at https://github.com/GoogleChrome/ioweb2016/issues/530#issuecomment-207576481

While we're using `<paper-dialog>` elsewhere, I don't immediately see any places in which we're explicitly styling its `position`.

Fixes #530 and I'm fairly certain it also fixes #459 
