### PR TITLE
Only set max-width on #mapContainer at smaller viewports

### DIFF
--- a/app/styles/pages/attend.scss
+++ b/app/styles/pages/attend.scss
@@ -277,8 +277,12 @@ $name: 'page-attend';
       height: 480px;
       background-color: #b3d1ff;
       position: relative;
-      max-width: 90%;
-      margin: 0 auto 0 auto;
+
+      // Ensure that there's room around the map to scroll on touch devices.
+      @media (max-width: $desktop-breakpoint-min + 50) {
+        max-width: 90%;
+        margin: 0 auto 0 auto;
+      }
 
       &::after {
         content: 'Loading...';

--- a/app/styles/pages/extended.scss
+++ b/app/styles/pages/extended.scss
@@ -165,8 +165,12 @@ $name: 'page-extended';
     background-color: #b3d1ff;
     padding-bottom: (1 / 2) * 100%;
     position: relative;
-    max-width: 90%;
-    margin: 0 auto 0 auto;
+
+    // Ensure that there's room around the map to scroll on touch devices.
+    @media (max-width: $desktop-breakpoint-min + 50) {
+      max-width: 90%;
+      margin: 0 auto 0 auto;
+    }
 
     @media (max-width: $tablet-breakpoint-min) {
       padding-bottom: (2 / 3) * 100%;


### PR DESCRIPTION
R: @ebidel 

Trying to find a happy medium between functionality and layout here. I couldn't just use the `$desktop-breakpoint-min` value as the trigger for `max-width: 90%`, since at that viewport width, there still isn't sufficient room on the margins for touch devices to scroll, so I'm looking for `$desktop-breakpoint-min + 50`.

Fixes #596
