### PR TITLE
Add aria-label to hashtag.

### DIFF
--- a/app/elements/io-home-page.html
+++ b/app/elements/io-home-page.html
@@ -190,7 +190,7 @@ limitations under the License.
 
         </div>
         <div class="card-content box card--bottom-right-clip fullbleed io__hash bg-bluegrey-50-40">
-          <a href="https://twitter.com/search?q=%23io16" target="_blank">
+          <a href="https://twitter.com/search?q=%23io16" target="_blank" aria-label="Search #io16 on Twitter">
             <template is="dom-if" if="[[_loadVideo]]">
               <card-video id="card-video"
                   src="/io2016/videos/hashtag-800.mp4"


### PR DESCRIPTION
When `_loadVideo` returns `false`, this tag ends up empty as the video template doesn't render. Added `aria-label` to give link context in this case.

Fixes #669.
