### PR TITLE
Add aria-label to schedule time header.

### DIFF
--- a/app/elements/io-schedule.html
+++ b/app/elements/io-schedule.html
@@ -36,9 +36,9 @@ limitations under the License.
   <div layout horizontal
        class$="[[_addClass('session-block', session.firstOfBlock)]]">
     <div class="schedule-block-title">
-      <h1 layout horizontal end>
-        <span>[[_getMeridiemPart(session.block, 0)]]</span>
-        <span class="schedule-block-meridiem">[[_getMeridiemLetter(session.block)]]</span>
+      <h1 layout horizontal end aria-label$="Start time: [[session.block]]">
+        <span aria-hidden="true">[[_getMeridiemPart(session.block, 0)]]</span>
+        <span aria-hidden="true" class="schedule-block-meridiem">[[_getMeridiemLetter(session.block)]]</span>
       </h1>
     </div>
     <div class$="schedule-row [[_addClass('saved', session.saved)]]"


### PR DESCRIPTION
Added an `aria-label` with content "Start time: XX" to each time `h1` in the schedule, then hid the HTML elements contained within. This way VoiceOver reads the label as a single unit instead. Used full meridiem as well for increase clarity over the single letter displayed visually.

Note that in order to make VoiceOver read "12PM" as "twelve PM" instead of "one two PM", you have to set the VoiceOver preferences to do so. Haven't found any html attributes or css properties to force this.

Fixes #648 and #649.
