### PR TITLE
Check to make sure propel is defined before using it

### DIFF
--- a/app/elements/io-notification-widget.html
+++ b/app/elements/io-notification-widget.html
@@ -119,22 +119,24 @@ The `<io-notification-widget>` element renders the notification toggle UI.
       attached: function() {
         // propel will be set inside the ready callback iff we're on a platform
         // that supports service worker push notifications.
-        if (propel) {
-          propel.addEventListener('statuschange', function(status) {
-            this._set_propelStatus(status);
-          }.bind(this));
-
-          IOWA.IOFirebase.registerToNotificationUpdates(function(value) {
-            this._set_firebaseStatus(value);
-          }.bind(this));
-
-          document.addEventListener('signin-change', function(e) {
-            if (!e.detail.user) {
-              // We logged out, so unsubscribe
-              propel.unsubscribe();
-            }
-          });
+        if (!propel) {
+          return;
         }
+
+        propel.addEventListener('statuschange', function(status) {
+          this._set_propelStatus(status);
+        }.bind(this));
+
+        IOWA.IOFirebase.registerToNotificationUpdates(function(value) {
+          this._set_firebaseStatus(value);
+        }.bind(this));
+
+        document.addEventListener('signin-change', function(e) {
+          if (!e.detail.user) {
+            // We logged out, so unsubscribe
+            propel.unsubscribe();
+          }
+        });
       },
 
       /**


### PR DESCRIPTION
R: @nicolasgarnier @ebidel @wibblymat 

There are a few other places in the element where `propel` is referenced, but looking at the code, I don't think they'd ever be called unless Propel is already defined. In the interest of readability, I left off explicitly checking whether `propel` is defined in those cases.

Fixes #679 
