### PR TITLE
Use networkFirst for speaker profile images

### DIFF
--- a/app/scripts/sw-toolbox/profile-images.js
+++ b/app/scripts/sw-toolbox/profile-images.js
@@ -18,7 +18,7 @@
   var DEFAULT_PROFILE_IMAGE_URL = 'images/touch/homescreen96.png';
 
   function profileImageRequest(request) {
-    return global.toolbox.cacheFirst(request).catch(function() {
+    return global.toolbox.networkFirst(request).catch(function() {
       return global.toolbox.cacheOnly(new Request(DEFAULT_PROFILE_IMAGE_URL));
     });
   }


### PR DESCRIPTION
R: @ebidel @GoogleChrome/ioweb-core 

Fixes #702 as best as we can, given that we have `opaque` responses from the server.
