### PR TITLE
Fixes #394. Reset focus to page insted of io logo

### DIFF
--- a/app/scripts/helper/a11y.js
+++ b/app/scripts/helper/a11y.js
@@ -81,13 +81,6 @@ IOWA.A11y = IOWA.A11y || (function() {
     });
   }
 
-  // Shortcut to set the focus to the first item in the navigation menu
-  function focusNavigation() {
-    // Temporarily focus the home link until we add in navigation
-    IOWA.Elements.Nav.querySelector('.io-logo-link').focus();
-    // IOWA.Elements.NavPaperTabs.items[0].firstElementChild.focus();
-  }
-
   // Pipe text to an aria-live region. This is automatically trigged
   // when toasts are shown.
   function announceLiveChange(e) {
@@ -113,7 +106,6 @@ IOWA.A11y = IOWA.A11y || (function() {
     init: init,
     addFocusStates: addFocusStates,
     removeFocusStates: removeFocusStates,
-    focusNavigation: focusNavigation,
     announceLiveChange: announceLiveChange,
     focusNewPage: focusNewPage
   };

--- a/app/scripts/helper/elements.js
+++ b/app/scripts/helper/elements.js
@@ -285,8 +285,9 @@ IOWA.Elements = (function() {
         target: IOWA.Elements.Scroller
       });
 
-      // Move focus to the top of the page
-      IOWA.A11y.focusNavigation();
+      // Kick focus back to the page
+      // User will start from the top of the document again
+      e.target.blur();
     };
 
     template.toggleDrawer = function() {


### PR DESCRIPTION
Focus navigation seems to only be used by backToTop and thinking about it, it doesn't serve much use focusing the i/o logo vs just resetting page focus. The immediate next tab stop will be the I/O logo and this fixes #394 as well.
