### PR TITLE
Fixes #622. Fix tweet cycler and add better roles

### DIFF
--- a/app/elements/io-home-page.html
+++ b/app/elements/io-home-page.html
@@ -96,7 +96,7 @@ limitations under the License.
           </div>
         </div>
         <div class="card-content box card__photo card--top-right-clip" relative>
-          <iron-pages id="photo_list" class="card--top-right-clip" on-transitionend="onTransitionEnd" selected="0" fit>
+          <iron-pages id="photo_list" class="card--top-right-clip" on-transitionend="onTransitionEnd" selected="0" fit role="marquee" aria-label="image carousel">
             <img src="/io2016/images/home/cardboard.jpg" class="card--top-right-clip" style="visibility: visible;" alt="A man wearing headphones looks through a Google cardboard device">
             <img src="/io2016/images/home/keynote.jpg" class="card--top-right-clip" alt="A woman presents a keynote address on stage at Google I/O">
             <img src="/io2016/images/home/design.jpg" class="card--top-right-clip" alt="An audience sits on bean bag chairs watching a presentation on design">
@@ -173,7 +173,7 @@ limitations under the License.
             <social-poller url="/io2016/api/v1/social" posts="{{socialPosts}}"
                            interval="30000"></social-poller>
 
-            <iron-pages id="social_list" selected="0" layout vertical>
+            <iron-pages id="social_list" selected="0" layout vertical role="marquee" aria-label="tweet carousel">
               <template is="dom-repeat" items="[[_limit(socialPosts, 5)]]" as="post">
                 <social-post view="card"
                              kind="[[post.kind]]"
@@ -181,7 +181,8 @@ limitations under the License.
                              url="[[post.url]]"
                              text="[[post.text]]"
                              when="[[post.when]]"
-                             layout vertical flex>
+                             layout vertical flex
+                             on-transitionend="onTransitionEnd">
                 </social-post>
               </template>
             </iron-pages>


### PR DESCRIPTION
I think https://github.com/GoogleChrome/ioweb2016/issues/239 accidentally removed the `on-transitionend` listener which was hiding non-visible tweets so this restores it. Also adds better roles and labels. Now the cyclers announce as `Marquee, image carousel` and `Marquee, tweet carousel`.
# ariaDeepCuts
