### PR TITLE
Override selected state of paper-tabs

### DIFF
--- a/app/scripts/helper/a11y.js
+++ b/app/scripts/helper/a11y.js
@@ -101,6 +101,13 @@ IOWA.A11y = IOWA.A11y || (function() {
   function focusNewPage() {
     if (isInitialPage) {
       isInitialPage = false;
+
+      // Override navigation paper-tabs' super annoying focus managment
+      var tab = IOWA.Elements.NavPaperTabs.querySelector('paper-tab[tabindex="0"]');
+      if (tab) {
+        tab.setAttribute('tabindex', '-1');
+      }
+
       return;
     }
 

--- a/app/templates/layout_full.html
+++ b/app/templates/layout_full.html
@@ -295,7 +295,8 @@ limitations under the License.
         </a>
       </div>
       <paper-tabs attr-for-selected="label"
-                  selected="{{selectedPage}}" activate-event="" tabindex="-1">
+                  selected="{{selectedPage}}" activate-event="" tabindex="-1"
+                  role="">
         <paper-tab label="schedule" tabindex="-1" role="">
           <a href="schedule#day1" data-ajax-link data-track-link="nav-schedule"
              data-transition="page-slide-transition"


### PR DESCRIPTION
I noticed if you initially visit a page like Schedule and tab through the menu, because the first paper-tab is "selected" the element will self apply a tabindex of 0 meaning you have to tab twice to get past it (once on the paper-tab and once on the anchor). This prevents paper-tabs from self applying tabindex=0 which only seems to happen on initial page load.
