### PR TITLE
Fix Multi-device notifications flow

### DIFF
--- a/app/elements/io-notification-widget.html
+++ b/app/elements/io-notification-widget.html
@@ -42,9 +42,12 @@ The `<io-notification-widget>` element renders the notification toggle UI.
           <p class="settings-note"><b>Note</b>: Notifications are activated per device. To receive notifications on multiple devices, sign in on each device, enable notifications, and make sure you're online. However, turning off notifications on one device will turn them off on all devices.</p>
         </div>
         <div>
-          The permission required for notifications has been denied. If you want to enable this feature you will need to change the permission setting.
+          The permission required for notifications has been denied on this browser/device. If you want to enable this feature you will need to change the permission setting.
           <br/>
-          <a href="permissions" target="_blank">Learn how</a>.
+          <a href="/io2016/permissions" target="_blank">Learn how</a>.
+        </div>
+        <div>
+          The permission required for notifications has not been granted on this browser/device. If you want to enable this feature you will need to reload the page.
         </div>
       </iron-pages>
     </div>
@@ -169,16 +172,21 @@ The `<io-notification-widget>` element renders the notification toggle UI.
             goog.propel.PropelClient.getPermissionState(),
             propel.getSubscription()
           ]).then(function(perm, sub) {
-            if (perm.state === 'granted' && !sub) {
+            if ((perm[0] === 'default' || perm[0] === 'granted') && !sub) {
+              // If the user is being prompted for notifications approval we display the box
+              // as ticked but disabled.
+              if (perm[0] === 'default') {
+                this.disabled = true;
+                this.checked = true;
+              }
               // 1. The global notification setting is on
-              // 2. This client already has permission for notifications
-              // 3. There is no current local subscription
+              // 2. There is no current local subscription
               // So we're going to subscribe locally. This state is most
               // likely to come about because the user signed out on this
               // device after they enabled notifications.
               propel.subscribe().catch(IOWA.Util.reportError);
             }
-          });
+          }.bind(this));
         }
       },
 
@@ -206,9 +214,13 @@ The `<io-notification-widget>` element renders the notification toggle UI.
           this.disabled = true;
           this.checked = false;
           this.autoSubscribe = false;
+        } else if (this._firebaseStatus) {
+          // Permission dialog was dismissed without answering and we are already have notifications
+          // enabled in other browsers/devices for that user.
+          this.$.pages.select(2);
+          this.disabled = true;
+          this.checked = false;
         } else {
-          // permission dialog was dismissed without answering, can still prompt again
-          this.$.pages.select(0);
           this.disabled = false;
           this.checked = false;
         }


### PR DESCRIPTION
Takes care of some corner case when the user has enabled notifications and signs-in multiple devices specifically:
- User signs-in a  new device scenario:
  1.  The user already authorized notifications on other devices.
  2.  The user logs in a new device. He is automatically prompted to enable notifications locally by the browser. While he is prompted to allow notifications the checkbox is now (fix 1) in a checked + disabled state.
  3.  If the user dismisses the dialog without answering we display a specific message (fix 2)
- If the user un-checks the notifications checkbox: we unchecked it from all other browsers with IOWA opened. (this was broken. fix 3)

Fixes #222 

@ebidel @jeffposnick  PTAL
