### PR TITLE
Go to extra lengths to clear out cached user info

### DIFF
--- a/app/elements/google-signin.html
+++ b/app/elements/google-signin.html
@@ -127,6 +127,9 @@ Fired when sign in fails for some reason.
               if (signedIn) {
                 this.handleSignIn();
               } else {
+                // This is likely to be redundant, but just ensure that the
+                // IndexedDB image cache is cleared if we know we're signed out.
+                this.clearCachedUserInfo();
                 IOWA.Analytics.updateTracker(
                     IOWA.Analytics.customDimensions.SIGNED_IN, false);
               }
@@ -166,6 +169,7 @@ Fired when sign in fails for some reason.
         },
 
         clearCachedUserInfo: function() {
+          this.user = null;
           return IOWA.SimpleDB.clearData(IOWA.SimpleDB.NAMES.USER);
         },
 
@@ -229,7 +233,6 @@ Fired when sign in fails for some reason.
          * Handles successful sign outs.
          */
         handleSignOut: function() {
-          this.user = null;
           this.signedIn = false;
           this.clearCachedUserInfo();
           this.fire('signin-change', {signedIn: false, user: null});


### PR DESCRIPTION
R: @ebidel @GoogleChrome/ioweb-core 

This adds in an extra call to clear out the IndexedDB cache of the user profile picture that runs whenever the auth library has loaded and we detect that the user isn't signed in.

The IndexedDB cache should normally be cleared whenever a user explicitly logs out, but I can imagine a scenario in which the user logs out and then quickly quits before IndexedDB is cleared, or a scenario in which the user is implicitly logged out because they revoked the OAuth 2 grant. This should handle both of those situations.

Fixes https://github.com/GoogleChrome/ioweb2016/issues/718
