### PR TITLE
Trim duplicate css from main page

### DIFF
--- a/app/elements/io-agenda.scss
+++ b/app/elements/io-agenda.scss
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 @import '_elements';
-@import '../styles/components/_card';
-@import '../styles/components/_app';
 
 $bottom-buffer: 25px;
 

--- a/app/elements/io-gadget.scss
+++ b/app/elements/io-gadget.scss
@@ -16,9 +16,6 @@
 
 @import '_elements';
 
-@import '../styles/components/_card';
-@import '../styles/components/_app';
-
 :host {
   overflow: hidden;
   display: block;

--- a/app/elements/io-schedule.scss
+++ b/app/elements/io-schedule.scss
@@ -16,10 +16,6 @@
 
 @import '_elements';
 
-@import '../styles/components/_app';
-@import '../styles/components/_card';
-
-
 $color-section-border: #eaeaea;
 $color-session-row-hover: rgba($color-bluegrey-50, 0.4);
 


### PR DESCRIPTION
R: @jeffposnick @nicolasgarnier @crhym3 @pengying 

This removes redundant css that's already included in the main.scss bundle. This won't work under shadow dom, but that's a contract we've already broken: https://github.com/GoogleChrome/ioweb2016/wiki/Shared-CSS-styles-and-shared-app-state#aside-the-app-currently-does-not-work-under-native-shadow-dom
