### PR TITLE
Make tabs work with...tab

### DIFF
--- a/app/elements/io-attend-page.html
+++ b/app/elements/io-attend-page.html
@@ -67,13 +67,11 @@ limitations under the License.
                     selected="[[selectedSubpage]]">
           <paper-tab label="event" link>
             <a href="#event" data-track-link="attending-event" data-ajax-link
-               layout horizontal center-center
-               tabindex="-1">Event</a>
+               layout horizontal center-center>Event</a>
           </paper-tab>
           <paper-tab label="travel" link>
             <a href="#travel" data-track-link="attending-travel" data-ajax-link
-               layout horizontal center-center
-               tabindex="-1">Travel</a>
+               layout horizontal center-center>Travel</a>
           </paper-tab>
         </paper-tabs>
       </div>

--- a/app/elements/io-schedule-subnav.html
+++ b/app/elements/io-schedule-subnav.html
@@ -84,32 +84,27 @@ Fired when the clears filter "x" is clicked.
       <paper-tab label="agenda" link>
         <a href="#agenda" data-track-link="schedule-agenda" data-ajax-link
                           layout horizontal center-center
-                          aria-label="agenda"
-                          tabindex="-1">Agenda</a>
+                          aria-label="agenda">Agenda</a>
       </paper-tab>
       <paper-tab label="day1" link>
         <a href="#day1" data-track-link="schedule-day1" data-ajax-link
                         layout horizontal center-center
-                        aria-label="may eighteenth"
-                        tabindex="-1">May 18</a>
+                        aria-label="may eighteenth">May 18</a>
       </paper-tab>
       <paper-tab label="day2" link>
         <a href="#day2" data-track-link="schedule-day2" data-ajax-link
                         layout horizontal center-center
-                        aria-label="may nineteenth"
-                        tabindex="-1">May 19</a>
+                        aria-label="may nineteenth">May 19</a>
       </paper-tab>
       <paper-tab label="day3" link>
         <a href="#day3" data-track-link="schedule-day3" data-ajax-link
                         layout horizontal center-center
-                        aria-label="may twentieth"
-                        tabindex="-1">May 20</a>
+                        aria-label="may twentieth">May 20</a>
       </paper-tab>
       <paper-tab label="myschedule" link>
         <a href="#myschedule" data-track-link="schedule-mysched" data-ajax-link
                               layout horizontal center-center
-                              aria-label="my schedule"
-                              tabindex="-1">My Schedule</a>
+                              aria-label="my schedule">My Schedule</a>
       </paper-tab>
     </paper-tabs>
   </template>

--- a/app/elements/shared-app-styles.html
+++ b/app/elements/shared-app-styles.html
@@ -119,6 +119,10 @@ limitations under the License.
         padding: 0 12px;
       }
 
+      paper-tab[link] a:focus {
+        background: rgba(0, 0, 0, 0.1);
+      }
+
       paper-tab[focused] a {
         background: rgba(0, 0, 0, 0.1);
       }


### PR DESCRIPTION
This makes paper-tabs in schedule and attend work with the tab key instead of just restricting them to arrow keys. Only downside is you have to hit tab twice after you initially enter the widget because paper-tabs will first send focus to the currently selected `paper-tab`. But because these elements have a `link` attribute, if the user hits enter while either the `paper-tab` or the underlying `a` are focused, that click will get sent to the `a` so everything will work
