### PR TITLE
Add tracking for auth init and analytics timeout

### DIFF
--- a/app/elements/google-signin.html
+++ b/app/elements/google-signin.html
@@ -134,6 +134,18 @@ Fired when sign in fails for some reason.
                     IOWA.Analytics.customDimensions.SIGNED_IN, false);
               }
 
+              // Track how long it takes for the initial auth attempt to run.
+              if (window.performance && window.performance.now) {
+                var time = Math.ceil(window.performance.now());
+                var label = signedIn ? 'signed in' : 'signed out';
+                debugLog('auth init:', time, 'ms');
+                IOWA.Analytics.trackPerf('auth', 'init', time, label);
+
+                // Track this separately as an event so it can be used in
+                // advanged segments.
+                IOWA.Analytics.trackEvent('auth', 'init', label, time);
+              }
+
               // Listens for future changes to the signin status.
               this.auth2.isSignedIn.listen(this.signinChangedHandler_);
             }.bind(this));

--- a/app/scripts/analytics.js
+++ b/app/scripts/analytics.js
@@ -78,7 +78,13 @@ IOWA.Analytics = IOWA.Analytics || (function(exports) {
     // timeout so the promise always resolves. In such cases, some hits
     // will be sent with missing custom dimension values, but that's better
     // than them not being sent at all.
-    setTimeout(this.readyState_.resolve.bind(this), this.READY_STATE_TIMEOUT_);
+    setTimeout(function() {
+      this.readyState_.resolve();
+
+      // Tracks that this happened and when it happened.
+      this.trackEvent('analytics', 'timeout', this.READY_STATE_TIMEOUT_,
+          window.performance && window.performance.now());
+    }.bind(this), this.READY_STATE_TIMEOUT_);
   };
 
   /**


### PR DESCRIPTION
Currently, the analytics code waits for 5000 ms before sending the first hit. This is necessary because we don't know at page load whether or not the user is signed in, and we want to set that custom dimension on the tracker so it can be associated with the initial pageview.

The 5000 ms amount was arbitrarily chosen. This PR adds additional tracking to see how long it takes the app to figure out if the user is signed in as well as how often the analytics timeout occurs, so we can tweak the 5000 ms amount if needed.
