### PR TITLE
backend: improve GCS sync debounce

### DIFF
--- a/backend/cache.go
+++ b/backend/cache.go
@@ -47,7 +47,7 @@ type cacheInterface interface {
 	// it returns errCacheMiss if item is not in the cache or expired.
 	get(c context.Context, key string) ([]byte, error)
 	// deleteMulti removes keys from mecache.
-	deleleMulti(c context.Context, keys []string) error
+	deleteMulti(c context.Context, keys []string) error
 	// flush flushes all items from memcache.
 	flush(c context.Context) error
 }
@@ -114,7 +114,7 @@ func (mc *memoryCache) get(c context.Context, key string) ([]byte, error) {
 	return item.data, nil
 }
 
-func (mc *memoryCache) deleleMulti(c context.Context, keys []string) error {
+func (mc *memoryCache) deleteMulti(c context.Context, keys []string) error {
 	sort.Strings(keys)
 	mc.Lock()
 	defer mc.Unlock()

--- a/backend/cache_gae.go
+++ b/backend/cache_gae.go
@@ -47,7 +47,7 @@ func (mc *gaeMemcache) get(c context.Context, key string) ([]byte, error) {
 	return item.Value, nil
 }
 
-func (mc *gaeMemcache) deleleMulti(c context.Context, keys []string) error {
+func (mc *gaeMemcache) deleteMulti(c context.Context, keys []string) error {
 	return memcache.DeleteMulti(c, keys)
 }
 

--- a/backend/db.go
+++ b/backend/db.go
@@ -186,7 +186,7 @@ func storeEventData(c context.Context, d *eventData) error {
 		return perr(err)
 	}
 	ent.Etag = hexKey(key)
-	cache.deleleMulti(c, allCachedEventDataKeys)
+	cache.deleteMulti(c, allCachedEventDataKeys)
 	return nil
 }
 

--- a/backend/handler.go
+++ b/backend/handler.go
@@ -394,8 +394,8 @@ func syncEventData(w http.ResponseWriter, r *http.Request) {
 		return nil
 	})
 
-	if _, cerr := cache.inc(c, syncGCSCacheKey, -1000, 0); cerr != nil {
-		errorf(c, cerr.Error())
+	if err := cache.deleteMulti(c, []string{syncGCSCacheKey}); err != nil {
+		errorf(c, err.Error())
 	}
 
 	if err != nil {


### PR DESCRIPTION
This will make the backend resilient to a very frequent CMS updates.

I have no idea why `cache.inc` instead of `cache.delete` but there
must've been a reason which I don't recall anymore.

@ebidel @wibblymat
