### PR TITLE
Modernize SW update toast

### DIFF
--- a/app/elements/io-toast.html
+++ b/app/elements/io-toast.html
@@ -157,14 +157,26 @@ Fired when a new toast appears.
        * @param {string} opt_action Optional action link.
        * @param {function} opt_actionHandler Optional handler to execute when
        *     the action is tapped.
+       * @param {Number} opt_duration Optional duration to show the toast for.
        */
-      showMessage: function(message, opt_tapHandler, opt_action, opt_actionHandler) {
+      showMessage: function(message, opt_tapHandler, opt_action,
+                            opt_actionHandler, opt_duration) {
+        this.close();
+
+        // Override duration just for this toast.
+        var originalDuration = this.duration;
+        if (typeof opt_duration !== 'undefined') {
+          this.duration = opt_duration;
+        }
+
         this.text = message;
         this._tapHandler = opt_tapHandler;
         this.action = opt_action;
         this._actionHandler = opt_actionHandler;
         this.$.internaltoast.show();
         this.fire('toast-message', {message: message});
+
+        this.duration = originalDuration; // reset site-wide duration.
       },
 
       _handleTap: function() {

--- a/app/scripts/helper/schedule.js
+++ b/app/scripts/helper/schedule.js
@@ -332,7 +332,8 @@ class Schedule {
       if (saved) {
         return notificationWidget.subscribeIfAble().then(subscribed => {
           if (subscribed) {
-            IOWA.Elements.Toast.showMessage('Added to My Schedule. ' + message);
+            IOWA.Elements.Toast.showMessage('Added to My Schedule. ' + message,
+                                            null, null, null, 5000);
           } else if (Notification.permission === 'denied') {
             // The subscription couldn't be completed due to the page
             // permissions for notifications being set to denied.
@@ -340,11 +341,13 @@ class Schedule {
               null, 'Learn how', () => window.open('permissions', '_blank'));
           } else {
             // Some other reason for not enabling notifications
-            IOWA.Elements.Toast.showMessage('Added to My Schedule.');
+            IOWA.Elements.Toast.showMessage('Added to My Schedule.',
+                                            null, null, null, 5000);
           }
         });
       }
-      IOWA.Elements.Toast.showMessage('Removed from My Schedule');
+      IOWA.Elements.Toast.showMessage('Removed from My Schedule',
+                                      null, null, null, 5000);
     } else {
       // If notificationWidget isn't present and we're not auth'ed, then display
       // a message about the schedule update being queued.

--- a/app/scripts/helper/service-worker-registration.js
+++ b/app/scripts/helper/service-worker-registration.js
@@ -68,8 +68,14 @@ IOWA.ServiceWorkerRegistration = (function() {
           window.location.reload();
         };
 
-        IOWA.Elements.Toast.showMessage(
-            'Tap here or refresh the page for the latest content.', tapHandler);
+        if (IOWA.Elements && IOWA.Elements.Toast &&
+            IOWA.Elements.Toast.showMessage) {
+          IOWA.Elements.Toast.showMessage(
+            'A new version of this app is available.', tapHandler, 'Refresh',
+            null, 0); // duration 0 indications shows the toast indefinitely.
+        } else {
+          tapHandler(); // Force reload if user never was shown the toast.
+        }
       }
     };
   }


### PR DESCRIPTION
R: @jeffposnick  @nicolasgarnier @pengying @GoogleChrome/ioweb-core 
- makes the sw update toast indefinite so users don't miss it. if another toast activates, it will be replaced.
- also allows customization of the duration
- makes the add/remove schedule toasts shorter.
- Fixes #785

<img width="364" alt="screen shot 2016-05-01 at 2 05 39 pm" src="https://cloud.githubusercontent.com/assets/238208/14944504/a251971a-0fa9-11e6-8d13-2a1f9c880bee.png">
