### PR TITLE
Add off screen links to text versions of hotel and venue maps.

### DIFF
--- a/app/elements/io-attend-page.html
+++ b/app/elements/io-attend-page.html
@@ -67,6 +67,12 @@ limitations under the License.
                 <h5 style="font-weight: normal;">
                   Google I/O is our annual developer festival with hands-on learning, technical talks, and a chance to hear more about Google&#8217;s latest developer products.
                 </h5>
+
+                <div layout flex end>
+                  <span class="card__footerlink" layout horiziontal justified center flex>
+                    <a class="-off-screen -off-screen-focus" href="https://docs.google.com/document/d/1ngwo5T-EEkATxu5lTB0dOPsGsrzClfVSmH9CkpOvi_g/edit">View list of stages</a>
+                  </span>
+                </div>
               </div>
               <a class="card-content box card-map" href="https://www.google.com/maps/d/viewer?mid=zw02JmrSGtIE.kcBDdSlNAd4Y" target="_blank" layout vertical>
                 <div layout flex end>
@@ -288,6 +294,7 @@ limitations under the License.
                   <h3 class="details--title">Hotels</h3>
                   <div class="details--info-block">
                     <p class="detail__text">We have room blocks at many hotels. Use the map below to find a hotel that&rsquo;s best for you.</p>
+                    <a class="-off-screen -off-screen-focus" href="https://docs.google.com/document/d/118nk5pu5-4dT3gEq5KnFl7iATJhXldLdo7PVXaATIxM/edit">View list of hotels</a>
                   </div>
                 </div>
               </div>

--- a/app/elements/shared-app-styles.html
+++ b/app/elements/shared-app-styles.html
@@ -180,6 +180,13 @@ limitations under the License.
         width: 1px;
       }
 
+      .-off-screen-focus:focus {
+        clip: auto;
+        height: auto;
+        overflow: auto;
+        width: auto;
+      }
+
       .-no-border {
         border: none !important;
       }

--- a/app/styles/pages/attend.scss
+++ b/app/styles/pages/attend.scss
@@ -37,7 +37,6 @@ $name: 'page-attend';
         }
       }
 
-
       p {
         @include typo-heading-2();
         line-height: 32px;
@@ -45,6 +44,10 @@ $name: 'page-attend';
         @media (max-width: $tablet-breakpoint-max) {
           @include typo-mobile-intro-card();
         }
+      }
+
+      .-off-screen-focus:focus {
+        position: static !important;
       }
     }
   }


### PR DESCRIPTION
Fix #840.

Links are off screen so not visible to visual users but placed on screen when tabbed to to avoid keyboard navigation confusion.
