### PR TITLE
Fixes #922. Use real buttons for add/remove icons. Fix busted paper-fab

### DIFF
--- a/app/elements/io-schedule.html
+++ b/app/elements/io-schedule.html
@@ -61,21 +61,29 @@ limitations under the License.
       </a>
 
       <div class="schedule-toggle-buttons">
-        <iron-icon icon="io:add-circle"
-                   class="schedule-add-button"
-                   on-click="onAddSession"></iron-icon>
-        <iron-icon icon="io:remove-circle"
-                   class="schedule-remove-button"
-                   on-click="onRemoveSession"></iron-icon>
+        <button class="schedule-add-button"
+                aria-label="Add session"
+                on-click="onAddSession">
+          <iron-icon icon="io:add-circle-outline"></iron-icon>
+        </button>
+        <button class="schedule-remove-button"
+                aria-label="Remove session"
+                on-click="onRemoveSession">
+          <iron-icon icon="io:remove-circle-outline"></iron-icon>
+        </button>
       </div>
 
       <div class="schedule-toggle-buttons-mobile">
-        <iron-icon icon="io:add-circle-outline"
-                   class="schedule-add-button"
-                   on-click="onAddSession"></iron-icon>
-        <iron-icon icon="io:remove-circle-outline"
-                   class="schedule-remove-button"
-                   on-click="onRemoveSession"></iron-icon>
+        <button class="schedule-add-button"
+                aria-label="Add session"
+                on-click="onAddSession">
+          <iron-icon icon="io:add-circle-outline"></iron-icon>
+        </button>
+        <button class="schedule-remove-button"
+                aria-label="Remove session"
+                on-click="onRemoveSession">
+          <iron-icon icon="io:remove-circle-outline"></iron-icon>
+        </button>
       </div>
 
     </div>

--- a/app/elements/io-schedule.scss
+++ b/app/elements/io-schedule.scss
@@ -267,6 +267,15 @@ $filterBannerHeight: 72px;
   display: none;
 }
 
+.schedule-add-button,
+.schedule-remove-button {
+  border: none;
+  padding: 0;
+  background: transparent;
+  cursor: pointer;
+  -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+}
+
 .schedule-toggle-buttons-mobile {
   cursor: pointer;
 

--- a/app/elements/io-session-details.html
+++ b/app/elements/io-session-details.html
@@ -95,7 +95,7 @@ limitations under the License.
           <paper-fab icon="[[_computeSessionSavedIcon(selectedSession.saved)]]"
                      mini="[[forceMobileUI]]"
                      class$="[[_addActiveClass(selectedSession.saved)]]"
-                     on-up="_onToggleSaveSession"
+                     on-click="_onToggleSaveSession"
                      aria-label$="[[_computeLabel(selectedSession.saved)]]"></paper-fab>
         </div>
         <div class="session__info__section session__details">

--- a/app/elements/shared-app-styles.html
+++ b/app/elements/shared-app-styles.html
@@ -95,7 +95,8 @@ limitations under the License.
                     0px 8px 8px 0px rgba(0,0,0,0.24);
       }
 
-      paper-fab:hover {
+      paper-fab:hover,
+      paper-fab.keyboard-focus {
         box-shadow: 0px 0px 14px 0px rgba(0,0,0,0.12),
                     0px 14px 14px 0px rgba(0,0,0,0.24);
       }


### PR DESCRIPTION
- Uses `<button>` for add/remove toggles so we get click handling for free. _Use the platform!_
- Changed session detail handler to `click` instead of `up` as it wasn't firing for the keyboard
- Made paper-fabs hover when keyboard focused

@ebidel PTAL
