### PR TITLE
Re-enable h2 push!

### DIFF
--- a/backend/h2preload.json
+++ b/backend/h2preload.json
@@ -1,2 +1,16 @@
 {
+  "home": {
+    "elements/elements.html": {
+      "type": "document"
+    },
+    "elements/elements.js": {
+      "type": "script"
+    },
+    "styles/main.css": {
+      "type": "style"
+    },
+    "scripts/site-scripts.js": {
+      "type": "script"
+    }
+  }
 }


### PR DESCRIPTION
R: @crhym3 @jeffposnick @pengying @nicolasgarnier 

 FF has been fixed since we disabled push in https://github.com/GoogleChrome/ioweb2016/issues/277.

Note: in dev, site-scripts.js and elements.js will show up as 404s in the console. That's because these files are generated in prod.
