### PR TITLE
Delay signin until after page transitions are done

### DIFF
--- a/app/scripts/helper/elements.js
+++ b/app/scripts/helper/elements.js
@@ -25,8 +25,8 @@ IOWA.Elements = (function() {
       document.body.removeEventListener('page-select', onPageSelect);
 
       // Load auth after initial page is setup. This helps do less upfront work
-      // until the main schedule data is returned by the worker.
-      // IOWA.Elements.GoogleSignIn.load = true;
+      // until the animations are done (esp. on mobile).
+      IOWA.Elements.GoogleSignIn.load = true;
 
       IOWA.Elements.Template.set('app.splashRemoved', true);
 

--- a/app/templates/layout_full.html
+++ b/app/templates/layout_full.html
@@ -257,7 +257,7 @@ limitations under the License.
 <template is="dom-bind" id="t">
 
 <google-signin client-id="{% .ClientID %}" scopes="profile email"
-               user="{{app.currentUser}}" load></google-signin>
+               user="{{app.currentUser}}"></google-signin>
 
 <!-- Responsive handlers -->
 <iron-media-query id="mq-phone" full query="(min-width:320px) and (max-width:768px)"


### PR DESCRIPTION
R: @jeffposnick @brendankenny @pengying @nicolasgarnier @wibblymat 

Gone back and forth a couple of times on this, but I was playing around on mobile and loading sign in (with all its iframe terribleness) really hurts the countdown startup animation on the homepage.
