### PR TITLE
Activate the cron job for sending push notifications

### DIFF
--- a/backend/cron.yaml.template
+++ b/backend/cron.yaml.template
@@ -11,6 +11,6 @@ cron:
 - description: user data wipeout
   url: $PREFIX$/task/wipeout
   schedule: every 24 hours
-#- description: sessions start notifications
-#  url: $PREFIX$/task/clock
-#  schedule: every 1 minutes
+- description: sessions start notifications
+  url: $PREFIX$/task/clock
+  schedule: every 1 minutes


### PR DESCRIPTION
@ebidel @crhym3 

I accidentally missed including this in the push notifications PR. Without this none of the notifications will be sent on schedule.

First notification is due to go out in 90 minutes, but no panic if it doesn't get deployed till after then - it will just get sent as soon as the deploy happens instead.
