### PR TITLE
Fix bug with bus schedule date parsing in Safari

### DIFF
--- a/app/elements/io-attend-bus-schedule.html
+++ b/app/elements/io-attend-bus-schedule.html
@@ -579,10 +579,27 @@ limitations under the License.
     },
 
     getDurationMinutes: function(depart, arrive) {
-      var start = new Date(depart);
-      var end = new Date(arrive);
+      var departParts = this.separateDateAndTime(depart);
+      var arriveParts = this.separateDateAndTime(arrive);
+      var departDateParts = this.dateSplit(departParts[0], '-');
+      var arriveDateParts = this.dateSplit(arriveParts[0], '-');
+      var departTimeParts = this.dateSplit(departParts[1], ':');
+      var arriveTimeParts = this.dateSplit(arriveParts[1], ':');
+
+      var start = new Date(departDateParts[0], departDateParts[1] - 1, departDateParts[2], departTimeParts[0], departTimeParts[1]);
+      var end = new Date(arriveDateParts[0], arriveDateParts[1] - 1, arriveDateParts[2], arriveTimeParts[0], arriveTimeParts[1]);
 
       return (end - start) / 60000; // milliseconds to minutes
+    },
+
+    separateDateAndTime: function(dateString) {
+      return dateString.split(' ');
+    },
+
+    dateSplit: function(dateString, separator) {
+      return dateString.split(separator).map(function(s) {
+        return parseInt(s, 10);
+      });
     },
 
     _computeSelectLabel: function(isToIO, selectLabelOptions) {

--- a/app/elements/io-attend-bus-schedule.scss
+++ b/app/elements/io-attend-bus-schedule.scss
@@ -168,6 +168,7 @@ $content-padding-mobile: 16px;
     &:after {
       background: $color-white;
       left: 4px;
+      z-index: 1;
     }
   }
 


### PR DESCRIPTION
The string being passed into `Date()` isn't valid format that Safari could handle. Manually break out relevant date and time pieces and passing in as separate parameters.

Also fixing missing start dot.