### PR TITLE
Improve settings focus state on black bg

### DIFF
--- a/app/templates/layout_full.html
+++ b/app/templates/layout_full.html
@@ -227,6 +227,9 @@ limitations under the License.
     #navbar.scrolled paper-tabs {
       --paper-tabs-selection-bar-color: var(--paper-blue-grey-600);
     }
+    #signin-nav-elements paper-icon-button {
+      --paper-icon-button-ink-color: currentcolor;
+    }
   </style>
 
   <script type="application/ld+json">


### PR DESCRIPTION
Currently the settings focus doesn't show up on the black background. This fixes that.

@ebidel PTAL

![screen shot 2016-05-18 at 11 20 24 am](https://cloud.githubusercontent.com/assets/1066253/15370175/8e8e693a-1cea-11e6-85ca-6521025bd78e.png)
